### PR TITLE
Add missing fields to statements API and create gitbook2md tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ go.work.sum
 .env
 
 # Project specific
-
+tmp/
 
 # IDE specific files
 .idea/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,22 @@ make test-run TEST=TestQuotesService_GetDailyQuotes
 make install-tools
 ```
 
+### ツール
+
+#### gitbook2md
+GitBookのドキュメントをMarkdownに変換するツール。J-Quants APIの公式ドキュメントをローカルで参照する際に便利。
+
+```bash
+# ビルド
+cd cmd/gitbook2md && go build
+
+# 使用方法1: HTMLファイルから変換
+./gitbook2md input.html output.md
+
+# 使用方法2: URLから直接変換
+./gitbook2md --url https://jpx.gitbook.io/j-quants-ja/api-reference/statements --output statements.md
+```
+
 ### 直接実行する場合
 ```bash
 # 依存関係の取得

--- a/README.md
+++ b/README.md
@@ -201,8 +201,37 @@ jquants/
 ├── types/         # カスタム型定義
 ├── docs/          # APIドキュメント
 ├── test/e2e/      # E2Eテスト
+├── cmd/           # コマンドラインツール
+│   └── gitbook2md/  # GitBook→Markdown変換ツール
 ├── *.go           # 各APIサービス実装
 └── Makefile       # ビルドタスク
+```
+
+## ツール
+
+### gitbook2md
+
+GitBookのドキュメントをMarkdown形式に変換するツールです。J-Quants APIの公式ドキュメントをローカルで参照する際に便利です。
+
+```bash
+# ビルド
+cd cmd/gitbook2md && go build
+
+# 使用方法1: HTMLファイルから変換
+./gitbook2md input.html output.md
+
+# 使用方法2: URLから直接変換（推奨）
+./gitbook2md --url https://jpx.gitbook.io/j-quants-ja/api-reference/statements --output statements.md
+```
+
+#### 使用例
+
+```bash
+# 財務情報APIのドキュメントを取得
+./gitbook2md --url https://jpx.gitbook.io/j-quants-ja/api-reference/statements --output docs/api/statements.md
+
+# 上場銘柄一覧APIのドキュメントを取得
+./gitbook2md --url https://jpx.gitbook.io/j-quants-ja/api-reference/listed_info --output docs/api/listed_info.md
 ```
 
 ## エラーハンドリング

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -82,6 +82,11 @@ func (a *Auth) GetRefreshToken() string {
 	return a.refreshToken
 }
 
+// GetIDToken returns the current ID token
+func (a *Auth) GetIDToken() string {
+	return a.idToken
+}
+
 // SetRefreshToken sets the refresh token
 func (a *Auth) SetRefreshToken(token string) {
 	a.refreshToken = token

--- a/cmd/gitbook2md/main.go
+++ b/cmd/gitbook2md/main.go
@@ -572,7 +572,8 @@ func main() {
 	if *output != "" {
 		// Create directory if needed
 		dir := filepath.Dir(*output)
-		if err := os.MkdirAll(dir, 0755); err != nil { // #nosec G301
+		// #nosec G301 -- Documentation directory needs to be readable
+		if err := os.MkdirAll(dir, 0755); err != nil {
 			log.Fatal("Failed to create directory:", err)
 		}
 		

--- a/cmd/gitbook2md/main.go
+++ b/cmd/gitbook2md/main.go
@@ -1,3 +1,5 @@
+// gitbook2md is a tool to convert GitBook HTML pages to Markdown format.
+// This tool is used for documentation purposes only and is not part of the main library.
 package main
 
 import (
@@ -26,7 +28,7 @@ func NewGitBookParser(debug bool) *GitBookParser {
 
 // ParseFile parses a GitBook HTML file and returns Markdown
 func (p *GitBookParser) ParseFile(filename string) (string, error) {
-	file, err := os.Open(filename)
+	file, err := os.Open(filename) // #nosec G304
 	if err != nil {
 		return "", err
 	}
@@ -513,7 +515,7 @@ func main() {
 		}
 		
 		if outputFile != "" {
-			err = os.WriteFile(outputFile, []byte(markdown), 0644)
+			err = os.WriteFile(outputFile, []byte(markdown), 0644) // #nosec G306
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -545,7 +547,7 @@ func main() {
 	}
 
 	// Create temporary file
-	tmpFile, err := os.CreateTemp("", "gitbook2md-*.html")
+	tmpFile, err := os.CreateTemp("", "gitbook2md-*.html") // #nosec G303
 	if err != nil {
 		log.Fatal("Failed to create temp file:", err)
 	}
@@ -557,7 +559,7 @@ func main() {
 	if err != nil {
 		log.Fatal("Failed to save HTML:", err)
 	}
-	tmpFile.Close()
+	_ = tmpFile.Close() // #nosec G104
 
 	// Parse the file
 	parser := NewGitBookParser(*debug)
@@ -570,11 +572,11 @@ func main() {
 	if *output != "" {
 		// Create directory if needed
 		dir := filepath.Dir(*output)
-		if err := os.MkdirAll(dir, 0755); err != nil {
+		if err := os.MkdirAll(dir, 0755); err != nil { // #nosec G301
 			log.Fatal("Failed to create directory:", err)
 		}
 		
-		err = os.WriteFile(*output, []byte(markdown), 0644)
+		err = os.WriteFile(*output, []byte(markdown), 0644) // #nosec G306
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/gitbook2md/main.go
+++ b/cmd/gitbook2md/main.go
@@ -1,0 +1,585 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// GitBookParser is a specialized parser for GitBook HTML pages
+type GitBookParser struct {
+	debug bool
+}
+
+// NewGitBookParser creates a new GitBook parser
+func NewGitBookParser(debug bool) *GitBookParser {
+	return &GitBookParser{debug: debug}
+}
+
+// ParseFile parses a GitBook HTML file and returns Markdown
+func (p *GitBookParser) ParseFile(filename string) (string, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	doc, err := html.Parse(file)
+	if err != nil {
+		return "", err
+	}
+
+	// Extract metadata
+	title := p.extractTitle(doc)
+	description := p.extractDescription(doc)
+
+	// Find main content
+	content := p.extractMainContent(doc)
+
+	// Build markdown
+	var markdown strings.Builder
+	
+	if title != "" {
+		markdown.WriteString("# " + title + "\n\n")
+	}
+	
+	if description != "" {
+		markdown.WriteString("> " + description + "\n\n")
+	}
+	
+	if content != "" {
+		markdown.WriteString(content)
+	}
+
+	return markdown.String(), nil
+}
+
+// extractTitle extracts the page title
+func (p *GitBookParser) extractTitle(n *html.Node) string {
+	if n.Type == html.ElementNode && n.Data == "title" {
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			if c.Type == html.TextNode {
+				title := strings.TrimSpace(c.Data)
+				// Remove " | J-Quants API" suffix
+				if idx := strings.Index(title, " | "); idx > 0 {
+					title = title[:idx]
+				}
+				return title
+			}
+		}
+	}
+
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if title := p.extractTitle(c); title != "" {
+			return title
+		}
+	}
+
+	return ""
+}
+
+// extractDescription extracts meta description
+func (p *GitBookParser) extractDescription(n *html.Node) string {
+	if n.Type == html.ElementNode && n.Data == "meta" {
+		var name, content string
+		for _, attr := range n.Attr {
+			if attr.Key == "name" && attr.Val == "description" {
+				name = attr.Val
+			}
+			if attr.Key == "content" {
+				content = attr.Val
+			}
+		}
+		if name == "description" && content != "" {
+			return content
+		}
+	}
+
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if desc := p.extractDescription(c); desc != "" {
+			return desc
+		}
+	}
+
+	return ""
+}
+
+// extractMainContent extracts the main content area
+func (p *GitBookParser) extractMainContent(n *html.Node) string {
+	// Strategy: Look for specific patterns in the HTML
+	// 1. Find script tags with id="__NEXT_DATA__" which contains JSON data
+	// 2. Look for main content divs
+	// 3. Extract text content from specific areas
+
+	var content strings.Builder
+
+	// Look for JSON data in script tags
+	jsonData := p.extractJSONData(n)
+	if jsonData != "" {
+		// Parse JSON and extract relevant content
+		content.WriteString(p.parseJSONContent(jsonData))
+	}
+
+	// Look for structured content
+	p.extractStructuredContent(n, &content)
+
+	return content.String()
+}
+
+// extractJSONData looks for __NEXT_DATA__ script tag
+func (p *GitBookParser) extractJSONData(n *html.Node) string {
+	if n.Type == html.ElementNode && n.Data == "script" {
+		for _, attr := range n.Attr {
+			if attr.Key == "id" && attr.Val == "__NEXT_DATA__" {
+				for c := n.FirstChild; c != nil; c = c.NextSibling {
+					if c.Type == html.TextNode {
+						return c.Data
+					}
+				}
+			}
+		}
+	}
+
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if data := p.extractJSONData(c); data != "" {
+			return data
+		}
+	}
+
+	return ""
+}
+
+// parseJSONContent extracts content from JSON data
+func (p *GitBookParser) parseJSONContent(jsonStr string) string {
+	// This is a simplified extraction
+	// In a real implementation, you'd parse the JSON properly
+	
+	var content strings.Builder
+
+	// Look for common patterns in the JSON
+	// Extract request/response examples
+	if strings.Contains(jsonStr, "```") {
+		// Extract code blocks
+		re := regexp.MustCompile("```[^`]*```")
+		matches := re.FindAllString(jsonStr, -1)
+		for _, match := range matches {
+			content.WriteString(match + "\n\n")
+		}
+	}
+
+	return content.String()
+}
+
+// extractStructuredContent extracts content from HTML structure
+func (p *GitBookParser) extractStructuredContent(n *html.Node, content *strings.Builder) {
+	// Skip script and style tags
+	if n.Type == html.ElementNode && (n.Data == "script" || n.Data == "style" || n.Data == "noscript") {
+		return
+	}
+
+	// Look for content patterns
+	if n.Type == html.ElementNode {
+		class := p.getAttr(n, "class")
+		
+		// Look for code blocks
+		if n.Data == "pre" || strings.Contains(class, "code") {
+			p.extractCodeBlock(n, content)
+			return
+		}
+
+		// Look for tables
+		if n.Data == "table" {
+			p.extractTable(n, content)
+			return
+		}
+
+		// Look for div-based tables
+		if n.Data == "div" && p.getAttr(n, "role") == "table" {
+			p.extractTable(n, content)
+			return
+		}
+
+		// Look for headings
+		if n.Data == "h1" || n.Data == "h2" || n.Data == "h3" || n.Data == "h4" {
+			p.extractHeading(n, content)
+			return
+		}
+
+		// Look for paragraphs with actual content
+		if n.Data == "p" {
+			text := p.extractText(n)
+			if len(text) > 20 && !strings.Contains(text, "mask-image") {
+				content.WriteString(text + "\n\n")
+			}
+			return
+		}
+
+		// Look for lists
+		if n.Data == "ul" || n.Data == "ol" {
+			p.extractList(n, content, n.Data == "ol")
+			return
+		}
+	}
+
+	// Process children
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		p.extractStructuredContent(c, content)
+	}
+}
+
+// extractCodeBlock extracts code blocks
+func (p *GitBookParser) extractCodeBlock(n *html.Node, content *strings.Builder) {
+	code := p.extractText(n)
+	if code != "" && !strings.Contains(code, "function") && !strings.Contains(code, "var ") {
+		content.WriteString("```\n")
+		content.WriteString(code)
+		content.WriteString("\n```\n\n")
+	}
+}
+
+// extractTable extracts and converts tables
+func (p *GitBookParser) extractTable(n *html.Node, content *strings.Builder) {
+	// Simple table extraction
+	var headers []string
+	var rows [][]string
+
+	// Find headers
+	p.findTableHeaders(n, &headers)
+	
+	// Find rows
+	p.findTableRows(n, &rows)
+
+	// Also check for div-based tables with role attributes
+	if len(headers) == 0 && len(rows) == 0 {
+		p.findDivTableContent(n, &headers, &rows)
+	}
+
+	if len(headers) > 0 {
+		// Write headers
+		content.WriteString("| ")
+		for _, h := range headers {
+			content.WriteString(h + " | ")
+		}
+		content.WriteString("\n|")
+		for range headers {
+			content.WriteString("------|")
+		}
+		content.WriteString("\n")
+
+		// Write rows
+		for _, row := range rows {
+			if len(row) > 0 {
+				content.WriteString("| ")
+				for _, cell := range row {
+					content.WriteString(cell + " | ")
+				}
+				content.WriteString("\n")
+			}
+		}
+		content.WriteString("\n")
+	}
+}
+
+// extractHeading extracts headings
+func (p *GitBookParser) extractHeading(n *html.Node, content *strings.Builder) {
+	level := n.Data[1] - '0'
+	text := p.extractText(n)
+	if text != "" {
+		content.WriteString(strings.Repeat("#", int(level)) + " " + text + "\n\n")
+	}
+}
+
+// extractList extracts lists
+func (p *GitBookParser) extractList(n *html.Node, content *strings.Builder, ordered bool) {
+	counter := 1
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if c.Type == html.ElementNode && c.Data == "li" {
+			text := p.extractText(c)
+			if text != "" {
+				if ordered {
+					content.WriteString(fmt.Sprintf("%d. %s\n", counter, text))
+					counter++
+				} else {
+					content.WriteString("- " + text + "\n")
+				}
+			}
+		}
+	}
+	content.WriteString("\n")
+}
+
+// Helper methods
+
+func (p *GitBookParser) getAttr(n *html.Node, key string) string {
+	for _, attr := range n.Attr {
+		if attr.Key == key {
+			return attr.Val
+		}
+	}
+	return ""
+}
+
+func (p *GitBookParser) extractText(n *html.Node) string {
+	var text strings.Builder
+	p.extractTextRecursive(n, &text)
+	return strings.TrimSpace(text.String())
+}
+
+func (p *GitBookParser) extractTextRecursive(n *html.Node, text *strings.Builder) {
+	if n.Type == html.TextNode {
+		text.WriteString(n.Data)
+	}
+
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if c.Type != html.ElementNode || (c.Data != "script" && c.Data != "style") {
+			p.extractTextRecursive(c, text)
+		}
+	}
+}
+
+func (p *GitBookParser) findTableHeaders(n *html.Node, headers *[]string) {
+	if n.Type == html.ElementNode {
+		if n.Data == "th" {
+			*headers = append(*headers, p.extractText(n))
+			return
+		}
+		if n.Data == "thead" {
+			// Process only thead
+			for c := n.FirstChild; c != nil; c = c.NextSibling {
+				p.findTableHeaders(c, headers)
+			}
+			return
+		}
+	}
+
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		p.findTableHeaders(c, headers)
+	}
+}
+
+func (p *GitBookParser) findTableRows(n *html.Node, rows *[][]string) {
+	if n.Type == html.ElementNode && n.Data == "tbody" {
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			if c.Type == html.ElementNode && c.Data == "tr" {
+				var row []string
+				for td := c.FirstChild; td != nil; td = td.NextSibling {
+					if td.Type == html.ElementNode && td.Data == "td" {
+						row = append(row, p.extractText(td))
+					}
+				}
+				if len(row) > 0 {
+					*rows = append(*rows, row)
+				}
+			}
+		}
+		return
+	}
+
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		p.findTableRows(c, rows)
+	}
+}
+
+// findDivTableContent looks for div-based tables with role attributes
+func (p *GitBookParser) findDivTableContent(n *html.Node, headers *[]string, rows *[][]string) {
+	// Look for role="table"
+	if n.Type == html.ElementNode && p.getAttr(n, "role") == "table" {
+		p.extractDivTable(n, headers, rows)
+		return
+	}
+
+	// Also check if we're looking at a data table section
+	if n.Type == html.ElementNode && n.Data == "div" {
+		// Check for headers with role="columnheader"
+		p.findDivHeaders(n, headers)
+		
+		// Check for rows with role="row"
+		p.findDivRows(n, rows)
+	}
+
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if len(*headers) == 0 && len(*rows) == 0 {
+			p.findDivTableContent(c, headers, rows)
+		}
+	}
+}
+
+// extractDivTable extracts content from div-based tables
+func (p *GitBookParser) extractDivTable(n *html.Node, headers *[]string, rows *[][]string) {
+	// Find all elements with role="columnheader" for headers
+	p.findDivHeaders(n, headers)
+	
+	// Find all elements with role="row" for data rows
+	p.findDivRows(n, rows)
+}
+
+// findDivHeaders finds div elements with role="columnheader"
+func (p *GitBookParser) findDivHeaders(n *html.Node, headers *[]string) {
+	if n.Type == html.ElementNode && p.getAttr(n, "role") == "columnheader" {
+		*headers = append(*headers, p.extractText(n))
+		return
+	}
+
+	// Look for rowgroup containing headers
+	if n.Type == html.ElementNode && p.getAttr(n, "role") == "rowgroup" {
+		// Check if this is a header rowgroup
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			if c.Type == html.ElementNode && p.getAttr(c, "role") == "row" {
+				// Check if this row contains columnheaders
+				hasHeaders := false
+				for gc := c.FirstChild; gc != nil; gc = gc.NextSibling {
+					if gc.Type == html.ElementNode && p.getAttr(gc, "role") == "columnheader" {
+						hasHeaders = true
+						break
+					}
+				}
+				if hasHeaders {
+					// Extract headers from this row
+					for gc := c.FirstChild; gc != nil; gc = gc.NextSibling {
+						if gc.Type == html.ElementNode && p.getAttr(gc, "role") == "columnheader" {
+							*headers = append(*headers, p.extractText(gc))
+						}
+					}
+					return
+				}
+			}
+		}
+	}
+
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if len(*headers) == 0 {
+			p.findDivHeaders(c, headers)
+		}
+	}
+}
+
+// findDivRows finds div elements with role="row" containing data cells
+func (p *GitBookParser) findDivRows(n *html.Node, rows *[][]string) {
+	if n.Type == html.ElementNode && p.getAttr(n, "role") == "rowgroup" {
+		// Skip header rowgroup
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			if c.Type == html.ElementNode && p.getAttr(c, "role") == "row" {
+				// Check if this row contains cells (not headers)
+				var row []string
+				hasCells := false
+				for gc := c.FirstChild; gc != nil; gc = gc.NextSibling {
+					if gc.Type == html.ElementNode && p.getAttr(gc, "role") == "cell" {
+						hasCells = true
+						row = append(row, p.extractText(gc))
+					}
+				}
+				if hasCells && len(row) > 0 {
+					*rows = append(*rows, row)
+				}
+			}
+		}
+		return
+	}
+
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		p.findDivRows(c, rows)
+	}
+}
+
+func main() {
+	var (
+		url    = flag.String("url", "", "URL to fetch and convert")
+		output = flag.String("output", "", "Output file path")
+		debug  = flag.Bool("debug", false, "Enable debug mode")
+	)
+	flag.Parse()
+
+	// Check if using old style arguments
+	if flag.NArg() > 0 && *url == "" {
+		// Old style: gitbook2md <input.html> [output.md]
+		inputFile := flag.Arg(0)
+		outputFile := ""
+		if flag.NArg() > 1 {
+			outputFile = flag.Arg(1)
+		}
+		
+		parser := NewGitBookParser(*debug || os.Getenv("DEBUG") == "true")
+		markdown, err := parser.ParseFile(inputFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		
+		if outputFile != "" {
+			err = os.WriteFile(outputFile, []byte(markdown), 0644)
+			if err != nil {
+				log.Fatal(err)
+			}
+			fmt.Printf("Wrote %s\n", outputFile)
+		} else {
+			fmt.Print(markdown)
+		}
+		return
+	}
+
+	// New style with URL
+	if *url == "" {
+		fmt.Println("Usage:")
+		fmt.Println("  gitbook2md <input.html> [output.md]")
+		fmt.Println("  gitbook2md --url <url> [--output <output.md>]")
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	// Download the HTML content
+	resp, err := http.Get(*url)
+	if err != nil {
+		log.Fatal("Failed to fetch URL:", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		log.Fatal("HTTP error:", resp.StatusCode)
+	}
+
+	// Create temporary file
+	tmpFile, err := os.CreateTemp("", "gitbook2md-*.html")
+	if err != nil {
+		log.Fatal("Failed to create temp file:", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
+
+	// Copy content to temp file
+	_, err = io.Copy(tmpFile, resp.Body)
+	if err != nil {
+		log.Fatal("Failed to save HTML:", err)
+	}
+	tmpFile.Close()
+
+	// Parse the file
+	parser := NewGitBookParser(*debug)
+	markdown, err := parser.ParseFile(tmpFile.Name())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Output
+	if *output != "" {
+		// Create directory if needed
+		dir := filepath.Dir(*output)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			log.Fatal("Failed to create directory:", err)
+		}
+		
+		err = os.WriteFile(*output, []byte(markdown), 0644)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("Wrote %s\n", *output)
+	} else {
+		fmt.Print(markdown)
+	}
+}

--- a/docs/statements.md
+++ b/docs/statements.md
@@ -2,6 +2,22 @@
 
 このドキュメントは、J-Quants APIの財務諸表エンドポイント (`/fins/statements`) のレスポンスデータ項目について説明します。
 
+## APIエンドポイント
+
+- **URL**: `https://api.jquants.com/v1/fins/statements`
+- **メソッド**: GET
+- **認証**: Authorization ヘッダーにBearer トークンが必要
+
+## リクエストパラメータ
+
+| パラメータ名 | 型 | 必須 | 説明 | 例 |
+|------------|-----|------|------|-----|
+| code | String | いずれか必須 | 4桁または5桁の銘柄コード | 86970 or 8697 |
+| date | String | いずれか必須 | 開示日 | 2022-01-05 or 20220105 |
+| pagination_key | String | いいえ | 検索の先頭を指定する文字列（過去の検索で返却されたpagination_keyを設定） | - |
+
+※ codeまたはdateのいずれかのパラメータが必須
+
 ## データ型について
 - すべてのフィールドは `String` 型で返されます
 - 数値データも文字列として格納されています
@@ -70,6 +86,8 @@
 | ResultDividendPerShare3rdQuarter | 第3四半期配当金（実績） | 単位：円 |
 | ResultDividendPerShareFiscalYearEnd | 期末配当金（実績） | 単位：円 |
 | ResultDividendPerShareAnnual | 年間配当金（実績） | 単位：円 |
+| DistributionsPerUnit(REIT) | 1口当たり分配金 | 単位：円 |
+| ResultTotalDividendPaidAnnual | 配当金総額 | 単位：円 |
 | ResultPayoutRatioAnnual | 配当性向（実績） | パーセント |
 
 #### 配当予想
@@ -80,8 +98,9 @@
 | ForecastDividendPerShare3rdQuarter | 第3四半期配当金（予想） | 単位：円 |
 | ForecastDividendPerShareFiscalYearEnd | 期末配当金（予想） | 単位：円 |
 | ForecastDividendPerShareAnnual | 年間配当金（予想） | 単位：円 |
-| ForecastPayoutRatioAnnual | 配当性向（予想） | パーセント |
 | ForecastDistributionsPerUnit(REIT) | 分配金（REIT）（予想） | 単位：円 |
+| ForecastTotalDividendPaidAnnual | 予想配当金総額 | 単位：円 |
+| ForecastPayoutRatioAnnual | 配当性向（予想） | パーセント |
 
 ### 5. 業績予想
 
@@ -106,8 +125,18 @@
 #### 翌期業績予想
 | フィールド名 | 日本語説明 | 備考 |
 |------------|----------|------|
+| NextYearForecastDividendPerShare1stQuarter | 翌期第1四半期配当金（予想） | 単位：円 |
+| NextYearForecastDividendPerShare2ndQuarter | 翌期第2四半期配当金（予想） | 単位：円 |
+| NextYearForecastDividendPerShare3rdQuarter | 翌期第3四半期配当金（予想） | 単位：円 |
+| NextYearForecastDividendPerShareFiscalYearEnd | 翌期期末配当金（予想） | 単位：円 |
 | NextYearForecastDividendPerShareAnnual | 翌期年間配当金（予想） | 単位：円 |
+| NextYearForecastDistributionsPerUnit(REIT) | 翌期分配金（REIT）（予想） | 単位：円 |
 | NextYearForecastPayoutRatioAnnual | 翌期配当性向（予想） | パーセント |
+| NextYearForecastNetSales2ndQuarter | 翌期第2四半期売上高（予想） | 単位：円 |
+| NextYearForecastOperatingProfit2ndQuarter | 翌期第2四半期営業利益（予想） | 単位：円 |
+| NextYearForecastOrdinaryProfit2ndQuarter | 翌期第2四半期経常利益（予想） | 単位：円 |
+| NextYearForecastProfit2ndQuarter | 翌期第2四半期純利益（予想） | 単位：円 |
+| NextYearForecastEarningsPerShare2ndQuarter | 翌期第2四半期1株当たり純利益（予想） | 単位：円 |
 | NextYearForecastNetSales | 翌期売上高（予想） | 単位：円 |
 | NextYearForecastOperatingProfit | 翌期営業利益（予想） | 単位：円 |
 | NextYearForecastOrdinaryProfit | 翌期経常利益（予想） | 単位：円 |
@@ -119,10 +148,14 @@
 | フィールド名 | 日本語説明 | 備考 |
 |------------|----------|------|
 | MaterialChangesInSubsidiaries | 重要な子会社の異動 | true/false |
-| SignificantChangesInTheScopeOfConsolidation | 連結範囲の重要な変更 | |
+| SignificantChangesInTheScopeOfConsolidation | 連結範囲の重要な変更 | 2024/7/22より追加 ※1 |
+| ChangesBasedOnRevisionsOfAccountingStandard | 会計基準等の改正に伴う会計方針の変更 | true/false |
 | ChangesOtherThanOnesBasedOnRevisionsOfAccountingStandard | 会計基準改正以外の変更 | true/false |
+| ChangesInAccountingEstimates | 会計上の見積りの変更 | true/false |
+| RetrospectiveRestatement | 修正再表示 | |
 | NumberOfIssuedAndOutstandingSharesAtTheEndOfFiscalYearIncludingTreasuryStock | 期末発行済株式数（自己株式を含む） | |
 | NumberOfTreasuryStockAtTheEndOfFiscalYear | 期末自己株式数 | |
+| AverageNumberOfShares | 期中平均株式数 | |
 
 ### 7. 単体財務数値
 
@@ -135,6 +168,23 @@
 - `NonConsolidatedProfit`: 単体当期純利益
 - など
 
+## 会計基準について
+
+APIから出力される各項目名は日本基準（JGAAP）の開示項目が基準となっています。そのため：
+
+- **IFRS**や**米国基準（USGAAP）**の開示データでは、経常利益（OrdinaryProfit）の概念が存在しないため、データが空欄となります
+- 各企業の採用する会計基準は`TypeOfDocument`フィールドで確認できます
+
+## 四半期開示見直し対応について
+
+2024/7/22より、決算短信サマリー様式の記載事項変更に伴い、以下の項目が追加されました：
+
+- **変更前**: 重要な子会社の異動（連結範囲の変更を伴う特定子会社の異動）
+- **変更後**: 連結範囲の重要な変更
+
+新項目: `SignificantChangesInTheScopeOfConsolidation`（期中における連結範囲の重要な変更）
+※1: 2024-07-21以前のデータには値が含まれません
+
 ## 使用上の注意
 
 1. **データ型の変換**: すべてのフィールドは文字列型で返されるため、数値計算を行う場合は適切な型変換が必要です。
@@ -146,6 +196,54 @@
 4. **会計期間の種類**: `TypeOfCurrentPeriod`は四半期（1Q-4Q）または通期（FY）を示します。5Qは特殊な場合に使用されます。
 
 5. **開示書類種別**: `TypeOfDocument`は会計基準（IFRS/JGAAP）や連結/単体の区別を含みます。
+
+## エラーレスポンス
+
+### 400 Bad Request
+```json
+{
+    "message": "This API requires at least 1 parameter as follows; 'date','code'."
+}
+```
+
+### 401 Unauthorized
+```json
+{
+    "message": "The incoming token is invalid or expired."
+}
+```
+
+### 500 Internal Server Error
+```json
+{
+    "message": "Unexpected error. Please try again later."
+}
+```
+
+### データサイズエラー
+```json
+{
+    "message": "Response data is too large. Specify parameters to reduce the acquired data range."
+}
+```
+
+## APIコールサンプル
+
+### cURL
+```bash
+idToken=<YOUR idToken> && curl https://api.jquants.com/v1/fins/statements?code=86970&date=20230130 -H "Authorization: Bearer $idToken"
+```
+
+### Python
+```python
+import requests
+import json
+
+idToken = "YOUR idToken"
+headers = {'Authorization': 'Bearer {}'.format(idToken)}
+r = requests.get("https://api.jquants.com/v1/fins/statements?code=86970&date=20230130", headers=headers)
+r.json()
+```
 
 ## 関連ドキュメント
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/utahta/jquants
 
 go 1.23.0
+
+require golang.org/x/net v0.41.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/net v0.41.0 h1:vBTly1HeNPEn3wtREYfy4GZ/NECgw2Cnl+nK6Nz3uvw=
+golang.org/x/net v0.41.0/go.mod h1:B/K4NNqkfmg07DQYrbwvSluqCJOOXwUjeb/5lOisjbA=

--- a/statements.go
+++ b/statements.go
@@ -10,6 +10,7 @@ import (
 
 // StatementsService は財務諸表データを取得するサービスです。
 // 売上高、利益、資産、ROE/ROAなどの財務指標を提供します。
+// 財務諸表API(/fins/statements)から四半期毎の決算短信サマリーデータを取得します。
 type StatementsService struct {
 	client client.HTTPClient
 }
@@ -62,6 +63,8 @@ type Statement struct {
 	ResultDividendPerShare3rdQuarter    *float64 `json:"ResultDividendPerShare3rdQuarter"`
 	ResultDividendPerShareFiscalYearEnd *float64 `json:"ResultDividendPerShareFiscalYearEnd"`
 	ResultDividendPerShareAnnual        *float64 `json:"ResultDividendPerShareAnnual"`
+	DistributionsPerUnitREIT            *float64 `json:"DistributionsPerUnit(REIT)"`
+	ResultTotalDividendPaidAnnual       *float64 `json:"ResultTotalDividendPaidAnnual"`
 	ResultPayoutRatioAnnual             *float64 `json:"ResultPayoutRatioAnnual"`
 
 	// 配当予想
@@ -70,8 +73,9 @@ type Statement struct {
 	ForecastDividendPerShare3rdQuarter    *float64 `json:"ForecastDividendPerShare3rdQuarter"`
 	ForecastDividendPerShareFiscalYearEnd *float64 `json:"ForecastDividendPerShareFiscalYearEnd"`
 	ForecastDividendPerShareAnnual        *float64 `json:"ForecastDividendPerShareAnnual"`
-	ForecastPayoutRatioAnnual             *float64 `json:"ForecastPayoutRatioAnnual"`
 	ForecastDistributionsPerUnitREIT      *float64 `json:"ForecastDistributionsPerUnit(REIT)"`
+	ForecastTotalDividendPaidAnnual       *float64 `json:"ForecastTotalDividendPaidAnnual"`
+	ForecastPayoutRatioAnnual             *float64 `json:"ForecastPayoutRatioAnnual"`
 
 	// 当期業績予想
 	ForecastNetSales         *float64 `json:"ForecastNetSales"`
@@ -88,22 +92,34 @@ type Statement struct {
 	ForecastEarningsPerShare2ndQuarter *float64 `json:"ForecastEarningsPerShare2ndQuarter"`
 
 	// 翌期業績予想
-	NextYearForecastDividendPerShareAnnual *float64 `json:"NextYearForecastDividendPerShareAnnual"`
-	NextYearForecastPayoutRatioAnnual      *float64 `json:"NextYearForecastPayoutRatioAnnual"`
-	NextYearForecastNetSales               *float64 `json:"NextYearForecastNetSales"`
-	NextYearForecastOperatingProfit        *float64 `json:"NextYearForecastOperatingProfit"`
-	NextYearForecastOrdinaryProfit         *float64 `json:"NextYearForecastOrdinaryProfit"`
-	NextYearForecastProfit                 *float64 `json:"NextYearForecastProfit"`
-	NextYearForecastEarningsPerShare       *float64 `json:"NextYearForecastEarningsPerShare"`
+	NextYearForecastDividendPerShare1stQuarter    *float64 `json:"NextYearForecastDividendPerShare1stQuarter"`
+	NextYearForecastDividendPerShare2ndQuarter    *float64 `json:"NextYearForecastDividendPerShare2ndQuarter"`
+	NextYearForecastDividendPerShare3rdQuarter    *float64 `json:"NextYearForecastDividendPerShare3rdQuarter"`
+	NextYearForecastDividendPerShareFiscalYearEnd *float64 `json:"NextYearForecastDividendPerShareFiscalYearEnd"`
+	NextYearForecastDividendPerShareAnnual        *float64 `json:"NextYearForecastDividendPerShareAnnual"`
+	NextYearForecastDistributionsPerUnitREIT       *float64 `json:"NextYearForecastDistributionsPerUnit(REIT)"`
+	NextYearForecastPayoutRatioAnnual              *float64 `json:"NextYearForecastPayoutRatioAnnual"`
+	NextYearForecastNetSales2ndQuarter            *float64 `json:"NextYearForecastNetSales2ndQuarter"`
+	NextYearForecastOperatingProfit2ndQuarter     *float64 `json:"NextYearForecastOperatingProfit2ndQuarter"`
+	NextYearForecastOrdinaryProfit2ndQuarter      *float64 `json:"NextYearForecastOrdinaryProfit2ndQuarter"`
+	NextYearForecastProfit2ndQuarter              *float64 `json:"NextYearForecastProfit2ndQuarter"`
+	NextYearForecastEarningsPerShare2ndQuarter    *float64 `json:"NextYearForecastEarningsPerShare2ndQuarter"`
+	NextYearForecastNetSales                       *float64 `json:"NextYearForecastNetSales"`
+	NextYearForecastOperatingProfit                *float64 `json:"NextYearForecastOperatingProfit"`
+	NextYearForecastOrdinaryProfit                 *float64 `json:"NextYearForecastOrdinaryProfit"`
+	NextYearForecastProfit                         *float64 `json:"NextYearForecastProfit"`
+	NextYearForecastEarningsPerShare               *float64 `json:"NextYearForecastEarningsPerShare"`
 
 	// その他
 	MaterialChangesInSubsidiaries                                                bool   `json:"MaterialChangesInSubsidiaries"`
 	SignificantChangesInTheScopeOfConsolidation                                  bool   `json:"SignificantChangesInTheScopeOfConsolidation"`
-	ChangesInAccountingEstimates                                                 bool   `json:"ChangesInAccountingEstimates"`
+	ChangesBasedOnRevisionsOfAccountingStandard                                  bool   `json:"ChangesBasedOnRevisionsOfAccountingStandard"`
 	ChangesOtherThanOnesBasedOnRevisionsOfAccountingStandard                     bool   `json:"ChangesOtherThanOnesBasedOnRevisionsOfAccountingStandard"`
+	ChangesInAccountingEstimates                                                 bool   `json:"ChangesInAccountingEstimates"`
 	RetrospectiveRestatement                                                     bool   `json:"RetrospectiveRestatement"`
 	NumberOfIssuedAndOutstandingSharesAtTheEndOfFiscalYearIncludingTreasuryStock *int64 `json:"NumberOfIssuedAndOutstandingSharesAtTheEndOfFiscalYearIncludingTreasuryStock"`
 	NumberOfTreasuryStockAtTheEndOfFiscalYear                                    *int64 `json:"NumberOfTreasuryStockAtTheEndOfFiscalYear"`
+	AverageNumberOfShares                                                        *int64 `json:"AverageNumberOfShares"`
 
 	// 単体財務数値
 	NonConsolidatedNetSales           *float64 `json:"NonConsolidatedNetSales"`
@@ -115,6 +131,34 @@ type Statement struct {
 	NonConsolidatedEquity             *float64 `json:"NonConsolidatedEquity"`
 	NonConsolidatedEquityToAssetRatio *float64 `json:"NonConsolidatedEquityToAssetRatio"`
 	NonConsolidatedBookValuePerShare  *float64 `json:"NonConsolidatedBookValuePerShare"`
+
+	// 単体予想（第2四半期）
+	ForecastNonConsolidatedNetSales2ndQuarter         *float64 `json:"ForecastNonConsolidatedNetSales2ndQuarter"`
+	ForecastNonConsolidatedOperatingProfit2ndQuarter  *float64 `json:"ForecastNonConsolidatedOperatingProfit2ndQuarter"`
+	ForecastNonConsolidatedOrdinaryProfit2ndQuarter   *float64 `json:"ForecastNonConsolidatedOrdinaryProfit2ndQuarter"`
+	ForecastNonConsolidatedProfit2ndQuarter           *float64 `json:"ForecastNonConsolidatedProfit2ndQuarter"`
+	ForecastNonConsolidatedEarningsPerShare2ndQuarter *float64 `json:"ForecastNonConsolidatedEarningsPerShare2ndQuarter"`
+
+	// 単体翌期予想（第2四半期）
+	NextYearForecastNonConsolidatedNetSales2ndQuarter         *float64 `json:"NextYearForecastNonConsolidatedNetSales2ndQuarter"`
+	NextYearForecastNonConsolidatedOperatingProfit2ndQuarter  *float64 `json:"NextYearForecastNonConsolidatedOperatingProfit2ndQuarter"`
+	NextYearForecastNonConsolidatedOrdinaryProfit2ndQuarter   *float64 `json:"NextYearForecastNonConsolidatedOrdinaryProfit2ndQuarter"`
+	NextYearForecastNonConsolidatedProfit2ndQuarter           *float64 `json:"NextYearForecastNonConsolidatedProfit2ndQuarter"`
+	NextYearForecastNonConsolidatedEarningsPerShare2ndQuarter *float64 `json:"NextYearForecastNonConsolidatedEarningsPerShare2ndQuarter"`
+
+	// 単体予想（期末）
+	ForecastNonConsolidatedNetSales         *float64 `json:"ForecastNonConsolidatedNetSales"`
+	ForecastNonConsolidatedOperatingProfit  *float64 `json:"ForecastNonConsolidatedOperatingProfit"`
+	ForecastNonConsolidatedOrdinaryProfit   *float64 `json:"ForecastNonConsolidatedOrdinaryProfit"`
+	ForecastNonConsolidatedProfit           *float64 `json:"ForecastNonConsolidatedProfit"`
+	ForecastNonConsolidatedEarningsPerShare *float64 `json:"ForecastNonConsolidatedEarningsPerShare"`
+
+	// 単体翌期予想（期末）
+	NextYearForecastNonConsolidatedNetSales         *float64 `json:"NextYearForecastNonConsolidatedNetSales"`
+	NextYearForecastNonConsolidatedOperatingProfit  *float64 `json:"NextYearForecastNonConsolidatedOperatingProfit"`
+	NextYearForecastNonConsolidatedOrdinaryProfit   *float64 `json:"NextYearForecastNonConsolidatedOrdinaryProfit"`
+	NextYearForecastNonConsolidatedProfit           *float64 `json:"NextYearForecastNonConsolidatedProfit"`
+	NextYearForecastNonConsolidatedEarningsPerShare *float64 `json:"NextYearForecastNonConsolidatedEarningsPerShare"`
 }
 
 // RawStatement is used for unmarshaling JSON response with mixed types
@@ -157,6 +201,8 @@ type RawStatement struct {
 	ResultDividendPerShare3rdQuarter    *types.Float64String `json:"ResultDividendPerShare3rdQuarter"`
 	ResultDividendPerShareFiscalYearEnd *types.Float64String `json:"ResultDividendPerShareFiscalYearEnd"`
 	ResultDividendPerShareAnnual        *types.Float64String `json:"ResultDividendPerShareAnnual"`
+	DistributionsPerUnitREIT            *types.Float64String `json:"DistributionsPerUnit(REIT)"`
+	ResultTotalDividendPaidAnnual       *types.Float64String `json:"ResultTotalDividendPaidAnnual"`
 	ResultPayoutRatioAnnual             *types.Float64String `json:"ResultPayoutRatioAnnual"`
 
 	// 配当予想
@@ -165,8 +211,9 @@ type RawStatement struct {
 	ForecastDividendPerShare3rdQuarter    *types.Float64String `json:"ForecastDividendPerShare3rdQuarter"`
 	ForecastDividendPerShareFiscalYearEnd *types.Float64String `json:"ForecastDividendPerShareFiscalYearEnd"`
 	ForecastDividendPerShareAnnual        *types.Float64String `json:"ForecastDividendPerShareAnnual"`
-	ForecastPayoutRatioAnnual             *types.Float64String `json:"ForecastPayoutRatioAnnual"`
 	ForecastDistributionsPerUnitREIT      *types.Float64String `json:"ForecastDistributionsPerUnit(REIT)"`
+	ForecastTotalDividendPaidAnnual       *types.Float64String `json:"ForecastTotalDividendPaidAnnual"`
+	ForecastPayoutRatioAnnual             *types.Float64String `json:"ForecastPayoutRatioAnnual"`
 
 	// 当期業績予想
 	ForecastNetSales         *types.Float64String `json:"ForecastNetSales"`
@@ -183,22 +230,34 @@ type RawStatement struct {
 	ForecastEarningsPerShare2ndQuarter *types.Float64String `json:"ForecastEarningsPerShare2ndQuarter"`
 
 	// 翌期業績予想
-	NextYearForecastDividendPerShareAnnual *types.Float64String `json:"NextYearForecastDividendPerShareAnnual"`
-	NextYearForecastPayoutRatioAnnual      *types.Float64String `json:"NextYearForecastPayoutRatioAnnual"`
-	NextYearForecastNetSales               *types.Float64String `json:"NextYearForecastNetSales"`
-	NextYearForecastOperatingProfit        *types.Float64String `json:"NextYearForecastOperatingProfit"`
-	NextYearForecastOrdinaryProfit         *types.Float64String `json:"NextYearForecastOrdinaryProfit"`
-	NextYearForecastProfit                 *types.Float64String `json:"NextYearForecastProfit"`
-	NextYearForecastEarningsPerShare       *types.Float64String `json:"NextYearForecastEarningsPerShare"`
+	NextYearForecastDividendPerShare1stQuarter    *types.Float64String `json:"NextYearForecastDividendPerShare1stQuarter"`
+	NextYearForecastDividendPerShare2ndQuarter    *types.Float64String `json:"NextYearForecastDividendPerShare2ndQuarter"`
+	NextYearForecastDividendPerShare3rdQuarter    *types.Float64String `json:"NextYearForecastDividendPerShare3rdQuarter"`
+	NextYearForecastDividendPerShareFiscalYearEnd *types.Float64String `json:"NextYearForecastDividendPerShareFiscalYearEnd"`
+	NextYearForecastDividendPerShareAnnual        *types.Float64String `json:"NextYearForecastDividendPerShareAnnual"`
+	NextYearForecastDistributionsPerUnitREIT       *types.Float64String `json:"NextYearForecastDistributionsPerUnit(REIT)"`
+	NextYearForecastPayoutRatioAnnual              *types.Float64String `json:"NextYearForecastPayoutRatioAnnual"`
+	NextYearForecastNetSales2ndQuarter            *types.Float64String `json:"NextYearForecastNetSales2ndQuarter"`
+	NextYearForecastOperatingProfit2ndQuarter     *types.Float64String `json:"NextYearForecastOperatingProfit2ndQuarter"`
+	NextYearForecastOrdinaryProfit2ndQuarter      *types.Float64String `json:"NextYearForecastOrdinaryProfit2ndQuarter"`
+	NextYearForecastProfit2ndQuarter              *types.Float64String `json:"NextYearForecastProfit2ndQuarter"`
+	NextYearForecastEarningsPerShare2ndQuarter    *types.Float64String `json:"NextYearForecastEarningsPerShare2ndQuarter"`
+	NextYearForecastNetSales                       *types.Float64String `json:"NextYearForecastNetSales"`
+	NextYearForecastOperatingProfit                *types.Float64String `json:"NextYearForecastOperatingProfit"`
+	NextYearForecastOrdinaryProfit                 *types.Float64String `json:"NextYearForecastOrdinaryProfit"`
+	NextYearForecastProfit                         *types.Float64String `json:"NextYearForecastProfit"`
+	NextYearForecastEarningsPerShare               *types.Float64String `json:"NextYearForecastEarningsPerShare"`
 
 	// その他
 	MaterialChangesInSubsidiaries                                                types.BoolString     `json:"MaterialChangesInSubsidiaries"`
 	SignificantChangesInTheScopeOfConsolidation                                  types.BoolString     `json:"SignificantChangesInTheScopeOfConsolidation"`
-	ChangesInAccountingEstimates                                                 types.BoolString     `json:"ChangesInAccountingEstimates"`
+	ChangesBasedOnRevisionsOfAccountingStandard                                  types.BoolString     `json:"ChangesBasedOnRevisionsOfAccountingStandard"`
 	ChangesOtherThanOnesBasedOnRevisionsOfAccountingStandard                     types.BoolString     `json:"ChangesOtherThanOnesBasedOnRevisionsOfAccountingStandard"`
+	ChangesInAccountingEstimates                                                 types.BoolString     `json:"ChangesInAccountingEstimates"`
 	RetrospectiveRestatement                                                     types.BoolString     `json:"RetrospectiveRestatement"`
 	NumberOfIssuedAndOutstandingSharesAtTheEndOfFiscalYearIncludingTreasuryStock *types.Float64String `json:"NumberOfIssuedAndOutstandingSharesAtTheEndOfFiscalYearIncludingTreasuryStock"`
 	NumberOfTreasuryStockAtTheEndOfFiscalYear                                    *types.Float64String `json:"NumberOfTreasuryStockAtTheEndOfFiscalYear"`
+	AverageNumberOfShares                                                        *types.Float64String `json:"AverageNumberOfShares"`
 
 	// 単体財務数値
 	NonConsolidatedNetSales           *types.Float64String `json:"NonConsolidatedNetSales"`
@@ -210,6 +269,34 @@ type RawStatement struct {
 	NonConsolidatedEquity             *types.Float64String `json:"NonConsolidatedEquity"`
 	NonConsolidatedEquityToAssetRatio *types.Float64String `json:"NonConsolidatedEquityToAssetRatio"`
 	NonConsolidatedBookValuePerShare  *types.Float64String `json:"NonConsolidatedBookValuePerShare"`
+
+	// 単体予想（第2四半期）
+	ForecastNonConsolidatedNetSales2ndQuarter         *types.Float64String `json:"ForecastNonConsolidatedNetSales2ndQuarter"`
+	ForecastNonConsolidatedOperatingProfit2ndQuarter  *types.Float64String `json:"ForecastNonConsolidatedOperatingProfit2ndQuarter"`
+	ForecastNonConsolidatedOrdinaryProfit2ndQuarter   *types.Float64String `json:"ForecastNonConsolidatedOrdinaryProfit2ndQuarter"`
+	ForecastNonConsolidatedProfit2ndQuarter           *types.Float64String `json:"ForecastNonConsolidatedProfit2ndQuarter"`
+	ForecastNonConsolidatedEarningsPerShare2ndQuarter *types.Float64String `json:"ForecastNonConsolidatedEarningsPerShare2ndQuarter"`
+
+	// 単体翌期予想（第2四半期）
+	NextYearForecastNonConsolidatedNetSales2ndQuarter         *types.Float64String `json:"NextYearForecastNonConsolidatedNetSales2ndQuarter"`
+	NextYearForecastNonConsolidatedOperatingProfit2ndQuarter  *types.Float64String `json:"NextYearForecastNonConsolidatedOperatingProfit2ndQuarter"`
+	NextYearForecastNonConsolidatedOrdinaryProfit2ndQuarter   *types.Float64String `json:"NextYearForecastNonConsolidatedOrdinaryProfit2ndQuarter"`
+	NextYearForecastNonConsolidatedProfit2ndQuarter           *types.Float64String `json:"NextYearForecastNonConsolidatedProfit2ndQuarter"`
+	NextYearForecastNonConsolidatedEarningsPerShare2ndQuarter *types.Float64String `json:"NextYearForecastNonConsolidatedEarningsPerShare2ndQuarter"`
+
+	// 単体予想（期末）
+	ForecastNonConsolidatedNetSales         *types.Float64String `json:"ForecastNonConsolidatedNetSales"`
+	ForecastNonConsolidatedOperatingProfit  *types.Float64String `json:"ForecastNonConsolidatedOperatingProfit"`
+	ForecastNonConsolidatedOrdinaryProfit   *types.Float64String `json:"ForecastNonConsolidatedOrdinaryProfit"`
+	ForecastNonConsolidatedProfit           *types.Float64String `json:"ForecastNonConsolidatedProfit"`
+	ForecastNonConsolidatedEarningsPerShare *types.Float64String `json:"ForecastNonConsolidatedEarningsPerShare"`
+
+	// 単体翌期予想（期末）
+	NextYearForecastNonConsolidatedNetSales         *types.Float64String `json:"NextYearForecastNonConsolidatedNetSales"`
+	NextYearForecastNonConsolidatedOperatingProfit  *types.Float64String `json:"NextYearForecastNonConsolidatedOperatingProfit"`
+	NextYearForecastNonConsolidatedOrdinaryProfit   *types.Float64String `json:"NextYearForecastNonConsolidatedOrdinaryProfit"`
+	NextYearForecastNonConsolidatedProfit           *types.Float64String `json:"NextYearForecastNonConsolidatedProfit"`
+	NextYearForecastNonConsolidatedEarningsPerShare *types.Float64String `json:"NextYearForecastNonConsolidatedEarningsPerShare"`
 }
 
 type StatementsResponse struct {
@@ -270,6 +357,8 @@ func (s *StatementsResponse) UnmarshalJSON(data []byte) error {
 			ResultDividendPerShare3rdQuarter:    types.ToFloat64Ptr(rs.ResultDividendPerShare3rdQuarter),
 			ResultDividendPerShareFiscalYearEnd: types.ToFloat64Ptr(rs.ResultDividendPerShareFiscalYearEnd),
 			ResultDividendPerShareAnnual:        types.ToFloat64Ptr(rs.ResultDividendPerShareAnnual),
+			DistributionsPerUnitREIT:            types.ToFloat64Ptr(rs.DistributionsPerUnitREIT),
+			ResultTotalDividendPaidAnnual:       types.ToFloat64Ptr(rs.ResultTotalDividendPaidAnnual),
 			ResultPayoutRatioAnnual:             types.ToFloat64Ptr(rs.ResultPayoutRatioAnnual),
 
 			// 配当予想
@@ -278,8 +367,9 @@ func (s *StatementsResponse) UnmarshalJSON(data []byte) error {
 			ForecastDividendPerShare3rdQuarter:    types.ToFloat64Ptr(rs.ForecastDividendPerShare3rdQuarter),
 			ForecastDividendPerShareFiscalYearEnd: types.ToFloat64Ptr(rs.ForecastDividendPerShareFiscalYearEnd),
 			ForecastDividendPerShareAnnual:        types.ToFloat64Ptr(rs.ForecastDividendPerShareAnnual),
-			ForecastPayoutRatioAnnual:             types.ToFloat64Ptr(rs.ForecastPayoutRatioAnnual),
 			ForecastDistributionsPerUnitREIT:      types.ToFloat64Ptr(rs.ForecastDistributionsPerUnitREIT),
+			ForecastTotalDividendPaidAnnual:       types.ToFloat64Ptr(rs.ForecastTotalDividendPaidAnnual),
+			ForecastPayoutRatioAnnual:             types.ToFloat64Ptr(rs.ForecastPayoutRatioAnnual),
 
 			// 当期業績予想
 			ForecastNetSales:         types.ToFloat64Ptr(rs.ForecastNetSales),
@@ -296,22 +386,34 @@ func (s *StatementsResponse) UnmarshalJSON(data []byte) error {
 			ForecastEarningsPerShare2ndQuarter: types.ToFloat64Ptr(rs.ForecastEarningsPerShare2ndQuarter),
 
 			// 翌期業績予想
-			NextYearForecastDividendPerShareAnnual: types.ToFloat64Ptr(rs.NextYearForecastDividendPerShareAnnual),
-			NextYearForecastPayoutRatioAnnual:      types.ToFloat64Ptr(rs.NextYearForecastPayoutRatioAnnual),
-			NextYearForecastNetSales:               types.ToFloat64Ptr(rs.NextYearForecastNetSales),
-			NextYearForecastOperatingProfit:        types.ToFloat64Ptr(rs.NextYearForecastOperatingProfit),
-			NextYearForecastOrdinaryProfit:         types.ToFloat64Ptr(rs.NextYearForecastOrdinaryProfit),
-			NextYearForecastProfit:                 types.ToFloat64Ptr(rs.NextYearForecastProfit),
-			NextYearForecastEarningsPerShare:       types.ToFloat64Ptr(rs.NextYearForecastEarningsPerShare),
+			NextYearForecastDividendPerShare1stQuarter:    types.ToFloat64Ptr(rs.NextYearForecastDividendPerShare1stQuarter),
+			NextYearForecastDividendPerShare2ndQuarter:    types.ToFloat64Ptr(rs.NextYearForecastDividendPerShare2ndQuarter),
+			NextYearForecastDividendPerShare3rdQuarter:    types.ToFloat64Ptr(rs.NextYearForecastDividendPerShare3rdQuarter),
+			NextYearForecastDividendPerShareFiscalYearEnd: types.ToFloat64Ptr(rs.NextYearForecastDividendPerShareFiscalYearEnd),
+			NextYearForecastDividendPerShareAnnual:        types.ToFloat64Ptr(rs.NextYearForecastDividendPerShareAnnual),
+			NextYearForecastDistributionsPerUnitREIT:       types.ToFloat64Ptr(rs.NextYearForecastDistributionsPerUnitREIT),
+			NextYearForecastPayoutRatioAnnual:              types.ToFloat64Ptr(rs.NextYearForecastPayoutRatioAnnual),
+			NextYearForecastNetSales2ndQuarter:            types.ToFloat64Ptr(rs.NextYearForecastNetSales2ndQuarter),
+			NextYearForecastOperatingProfit2ndQuarter:     types.ToFloat64Ptr(rs.NextYearForecastOperatingProfit2ndQuarter),
+			NextYearForecastOrdinaryProfit2ndQuarter:      types.ToFloat64Ptr(rs.NextYearForecastOrdinaryProfit2ndQuarter),
+			NextYearForecastProfit2ndQuarter:              types.ToFloat64Ptr(rs.NextYearForecastProfit2ndQuarter),
+			NextYearForecastEarningsPerShare2ndQuarter:    types.ToFloat64Ptr(rs.NextYearForecastEarningsPerShare2ndQuarter),
+			NextYearForecastNetSales:                       types.ToFloat64Ptr(rs.NextYearForecastNetSales),
+			NextYearForecastOperatingProfit:                types.ToFloat64Ptr(rs.NextYearForecastOperatingProfit),
+			NextYearForecastOrdinaryProfit:                 types.ToFloat64Ptr(rs.NextYearForecastOrdinaryProfit),
+			NextYearForecastProfit:                         types.ToFloat64Ptr(rs.NextYearForecastProfit),
+			NextYearForecastEarningsPerShare:               types.ToFloat64Ptr(rs.NextYearForecastEarningsPerShare),
 
 			// その他
 			MaterialChangesInSubsidiaries:                                                types.ToBool(rs.MaterialChangesInSubsidiaries),
 			SignificantChangesInTheScopeOfConsolidation:                                  types.ToBool(rs.SignificantChangesInTheScopeOfConsolidation),
-			ChangesInAccountingEstimates:                                                 types.ToBool(rs.ChangesInAccountingEstimates),
+			ChangesBasedOnRevisionsOfAccountingStandard:                                  types.ToBool(rs.ChangesBasedOnRevisionsOfAccountingStandard),
 			ChangesOtherThanOnesBasedOnRevisionsOfAccountingStandard:                     types.ToBool(rs.ChangesOtherThanOnesBasedOnRevisionsOfAccountingStandard),
+			ChangesInAccountingEstimates:                                                 types.ToBool(rs.ChangesInAccountingEstimates),
 			RetrospectiveRestatement:                                                     types.ToBool(rs.RetrospectiveRestatement),
 			NumberOfIssuedAndOutstandingSharesAtTheEndOfFiscalYearIncludingTreasuryStock: types.ToInt64Ptr(rs.NumberOfIssuedAndOutstandingSharesAtTheEndOfFiscalYearIncludingTreasuryStock),
 			NumberOfTreasuryStockAtTheEndOfFiscalYear:                                    types.ToInt64Ptr(rs.NumberOfTreasuryStockAtTheEndOfFiscalYear),
+			AverageNumberOfShares:                                                        types.ToInt64Ptr(rs.AverageNumberOfShares),
 
 			// 単体財務数値
 			NonConsolidatedNetSales:           types.ToFloat64Ptr(rs.NonConsolidatedNetSales),
@@ -323,6 +425,34 @@ func (s *StatementsResponse) UnmarshalJSON(data []byte) error {
 			NonConsolidatedEquity:             types.ToFloat64Ptr(rs.NonConsolidatedEquity),
 			NonConsolidatedEquityToAssetRatio: types.ToFloat64Ptr(rs.NonConsolidatedEquityToAssetRatio),
 			NonConsolidatedBookValuePerShare:  types.ToFloat64Ptr(rs.NonConsolidatedBookValuePerShare),
+
+			// 単体予想（第2四半期）
+			ForecastNonConsolidatedNetSales2ndQuarter:         types.ToFloat64Ptr(rs.ForecastNonConsolidatedNetSales2ndQuarter),
+			ForecastNonConsolidatedOperatingProfit2ndQuarter:  types.ToFloat64Ptr(rs.ForecastNonConsolidatedOperatingProfit2ndQuarter),
+			ForecastNonConsolidatedOrdinaryProfit2ndQuarter:   types.ToFloat64Ptr(rs.ForecastNonConsolidatedOrdinaryProfit2ndQuarter),
+			ForecastNonConsolidatedProfit2ndQuarter:           types.ToFloat64Ptr(rs.ForecastNonConsolidatedProfit2ndQuarter),
+			ForecastNonConsolidatedEarningsPerShare2ndQuarter: types.ToFloat64Ptr(rs.ForecastNonConsolidatedEarningsPerShare2ndQuarter),
+
+			// 単体翌期予想（第2四半期）
+			NextYearForecastNonConsolidatedNetSales2ndQuarter:         types.ToFloat64Ptr(rs.NextYearForecastNonConsolidatedNetSales2ndQuarter),
+			NextYearForecastNonConsolidatedOperatingProfit2ndQuarter:  types.ToFloat64Ptr(rs.NextYearForecastNonConsolidatedOperatingProfit2ndQuarter),
+			NextYearForecastNonConsolidatedOrdinaryProfit2ndQuarter:   types.ToFloat64Ptr(rs.NextYearForecastNonConsolidatedOrdinaryProfit2ndQuarter),
+			NextYearForecastNonConsolidatedProfit2ndQuarter:           types.ToFloat64Ptr(rs.NextYearForecastNonConsolidatedProfit2ndQuarter),
+			NextYearForecastNonConsolidatedEarningsPerShare2ndQuarter: types.ToFloat64Ptr(rs.NextYearForecastNonConsolidatedEarningsPerShare2ndQuarter),
+
+			// 単体予想（期末）
+			ForecastNonConsolidatedNetSales:         types.ToFloat64Ptr(rs.ForecastNonConsolidatedNetSales),
+			ForecastNonConsolidatedOperatingProfit:  types.ToFloat64Ptr(rs.ForecastNonConsolidatedOperatingProfit),
+			ForecastNonConsolidatedOrdinaryProfit:   types.ToFloat64Ptr(rs.ForecastNonConsolidatedOrdinaryProfit),
+			ForecastNonConsolidatedProfit:           types.ToFloat64Ptr(rs.ForecastNonConsolidatedProfit),
+			ForecastNonConsolidatedEarningsPerShare: types.ToFloat64Ptr(rs.ForecastNonConsolidatedEarningsPerShare),
+
+			// 単体翌期予想（期末）
+			NextYearForecastNonConsolidatedNetSales:         types.ToFloat64Ptr(rs.NextYearForecastNonConsolidatedNetSales),
+			NextYearForecastNonConsolidatedOperatingProfit:  types.ToFloat64Ptr(rs.NextYearForecastNonConsolidatedOperatingProfit),
+			NextYearForecastNonConsolidatedOrdinaryProfit:   types.ToFloat64Ptr(rs.NextYearForecastNonConsolidatedOrdinaryProfit),
+			NextYearForecastNonConsolidatedProfit:           types.ToFloat64Ptr(rs.NextYearForecastNonConsolidatedProfit),
+			NextYearForecastNonConsolidatedEarningsPerShare: types.ToFloat64Ptr(rs.NextYearForecastNonConsolidatedEarningsPerShare),
 		}
 	}
 
@@ -378,4 +508,10 @@ func (s *StatementsService) GetLatestStatements(code string) (*Statement, error)
 	}
 
 	return &latestStmt, nil
+}
+
+// GetStatementsByDate は指定日の財務諸表データを取得します。
+// 例: GetStatementsByDate("2024-01-15") で特定日に開示された全銘柄の決算データを取得
+func (s *StatementsService) GetStatementsByDate(date string) ([]Statement, error) {
+	return s.GetStatements("", date)
 }

--- a/test/e2e/statements_test.go
+++ b/test/e2e/statements_test.go
@@ -142,6 +142,10 @@ func TestStatementsEndpoint(t *testing.T) {
 		validateFinancialValue(t, "ResultDividendPerShareFiscalYearEnd", latest.ResultDividendPerShareFiscalYearEnd)
 		validateFinancialValue(t, "ResultPayoutRatioAnnual", latest.ResultPayoutRatioAnnual)
 		
+		// 新規追加フィールド: REIT関連と配当総額
+		validateFinancialValue(t, "DistributionsPerUnitREIT", latest.DistributionsPerUnitREIT)
+		validateFinancialValue(t, "ResultTotalDividendPaidAnnual", latest.ResultTotalDividendPaidAnnual)
+		
 		// 予想配当情報の検証
 		validateFinancialValue(t, "ForecastDividendPerShareAnnual", latest.ForecastDividendPerShareAnnual)
 		validateFinancialValue(t, "ForecastDividendPerShare1stQuarter", latest.ForecastDividendPerShare1stQuarter)
@@ -150,6 +154,10 @@ func TestStatementsEndpoint(t *testing.T) {
 		validateFinancialValue(t, "ForecastDividendPerShareFiscalYearEnd", latest.ForecastDividendPerShareFiscalYearEnd)
 		validateFinancialValue(t, "ForecastPayoutRatioAnnual", latest.ForecastPayoutRatioAnnual)
 		
+		// 新規追加フィールド: 予想REIT関連と配当総額
+		validateFinancialValue(t, "ForecastDistributionsPerUnitREIT", latest.ForecastDistributionsPerUnitREIT)
+		validateFinancialValue(t, "ForecastTotalDividendPaidAnnual", latest.ForecastTotalDividendPaidAnnual)
+		
 		// 予想財務データの検証
 		validateFinancialValue(t, "ForecastNetSales", latest.ForecastNetSales)
 		validateFinancialValue(t, "ForecastOperatingProfit", latest.ForecastOperatingProfit)
@@ -157,9 +165,40 @@ func TestStatementsEndpoint(t *testing.T) {
 		validateFinancialValue(t, "ForecastProfit", latest.ForecastProfit)
 		validateFinancialValue(t, "ForecastEarningsPerShare", latest.ForecastEarningsPerShare)
 		
+		// 第2四半期予想
+		validateFinancialValue(t, "ForecastNetSales2ndQuarter", latest.ForecastNetSales2ndQuarter)
+		validateFinancialValue(t, "ForecastOperatingProfit2ndQuarter", latest.ForecastOperatingProfit2ndQuarter)
+		validateFinancialValue(t, "ForecastOrdinaryProfit2ndQuarter", latest.ForecastOrdinaryProfit2ndQuarter)
+		validateFinancialValue(t, "ForecastProfit2ndQuarter", latest.ForecastProfit2ndQuarter)
+		validateFinancialValue(t, "ForecastEarningsPerShare2ndQuarter", latest.ForecastEarningsPerShare2ndQuarter)
+		
+		// 翌期予想配当
+		validateFinancialValue(t, "NextYearForecastDividendPerShare1stQuarter", latest.NextYearForecastDividendPerShare1stQuarter)
+		validateFinancialValue(t, "NextYearForecastDividendPerShare2ndQuarter", latest.NextYearForecastDividendPerShare2ndQuarter)
+		validateFinancialValue(t, "NextYearForecastDividendPerShare3rdQuarter", latest.NextYearForecastDividendPerShare3rdQuarter)
+		validateFinancialValue(t, "NextYearForecastDividendPerShareFiscalYearEnd", latest.NextYearForecastDividendPerShareFiscalYearEnd)
+		validateFinancialValue(t, "NextYearForecastDividendPerShareAnnual", latest.NextYearForecastDividendPerShareAnnual)
+		validateFinancialValue(t, "NextYearForecastDistributionsPerUnitREIT", latest.NextYearForecastDistributionsPerUnitREIT)
+		validateFinancialValue(t, "NextYearForecastPayoutRatioAnnual", latest.NextYearForecastPayoutRatioAnnual)
+		
+		// 翌期第2四半期予想
+		validateFinancialValue(t, "NextYearForecastNetSales2ndQuarter", latest.NextYearForecastNetSales2ndQuarter)
+		validateFinancialValue(t, "NextYearForecastOperatingProfit2ndQuarter", latest.NextYearForecastOperatingProfit2ndQuarter)
+		validateFinancialValue(t, "NextYearForecastOrdinaryProfit2ndQuarter", latest.NextYearForecastOrdinaryProfit2ndQuarter)
+		validateFinancialValue(t, "NextYearForecastProfit2ndQuarter", latest.NextYearForecastProfit2ndQuarter)
+		validateFinancialValue(t, "NextYearForecastEarningsPerShare2ndQuarter", latest.NextYearForecastEarningsPerShare2ndQuarter)
+		
+		// 翌期通期予想
+		validateFinancialValue(t, "NextYearForecastNetSales", latest.NextYearForecastNetSales)
+		validateFinancialValue(t, "NextYearForecastOperatingProfit", latest.NextYearForecastOperatingProfit)
+		validateFinancialValue(t, "NextYearForecastOrdinaryProfit", latest.NextYearForecastOrdinaryProfit)
+		validateFinancialValue(t, "NextYearForecastProfit", latest.NextYearForecastProfit)
+		validateFinancialValue(t, "NextYearForecastEarningsPerShare", latest.NextYearForecastEarningsPerShare)
+		
 		// 修正情報の検証（bool型フィールド）
 		t.Logf("MaterialChangesInSubsidiaries: %v", latest.MaterialChangesInSubsidiaries)
 		t.Logf("SignificantChangesInTheScopeOfConsolidation: %v", latest.SignificantChangesInTheScopeOfConsolidation)
+		t.Logf("ChangesBasedOnRevisionsOfAccountingStandard: %v", latest.ChangesBasedOnRevisionsOfAccountingStandard)
 		t.Logf("ChangesOtherThanOnesBasedOnRevisionsOfAccountingStandard: %v", latest.ChangesOtherThanOnesBasedOnRevisionsOfAccountingStandard)
 		t.Logf("ChangesInAccountingEstimates: %v", latest.ChangesInAccountingEstimates)
 		t.Logf("RetrospectiveRestatement: %v", latest.RetrospectiveRestatement)
@@ -173,6 +212,48 @@ func TestStatementsEndpoint(t *testing.T) {
 			t.Logf("NumberOfTreasuryStockAtTheEndOfFiscalYear: %d", 
 				*latest.NumberOfTreasuryStockAtTheEndOfFiscalYear)
 		}
+		if latest.AverageNumberOfShares != nil {
+			t.Logf("AverageNumberOfShares: %d", *latest.AverageNumberOfShares)
+		}
+		
+		// 単体財務データの検証
+		validateFinancialValue(t, "NonConsolidatedNetSales", latest.NonConsolidatedNetSales)
+		validateFinancialValue(t, "NonConsolidatedOperatingProfit", latest.NonConsolidatedOperatingProfit)
+		validateFinancialValue(t, "NonConsolidatedOrdinaryProfit", latest.NonConsolidatedOrdinaryProfit)
+		validateFinancialValue(t, "NonConsolidatedProfit", latest.NonConsolidatedProfit)
+		validateFinancialValue(t, "NonConsolidatedEarningsPerShare", latest.NonConsolidatedEarningsPerShare)
+		validateFinancialValue(t, "NonConsolidatedTotalAssets", latest.NonConsolidatedTotalAssets)
+		validateFinancialValue(t, "NonConsolidatedEquity", latest.NonConsolidatedEquity)
+		validateFinancialValue(t, "NonConsolidatedEquityToAssetRatio", latest.NonConsolidatedEquityToAssetRatio)
+		validateFinancialValue(t, "NonConsolidatedBookValuePerShare", latest.NonConsolidatedBookValuePerShare)
+		
+		// 単体予想（第2四半期）
+		validateFinancialValue(t, "ForecastNonConsolidatedNetSales2ndQuarter", latest.ForecastNonConsolidatedNetSales2ndQuarter)
+		validateFinancialValue(t, "ForecastNonConsolidatedOperatingProfit2ndQuarter", latest.ForecastNonConsolidatedOperatingProfit2ndQuarter)
+		validateFinancialValue(t, "ForecastNonConsolidatedOrdinaryProfit2ndQuarter", latest.ForecastNonConsolidatedOrdinaryProfit2ndQuarter)
+		validateFinancialValue(t, "ForecastNonConsolidatedProfit2ndQuarter", latest.ForecastNonConsolidatedProfit2ndQuarter)
+		validateFinancialValue(t, "ForecastNonConsolidatedEarningsPerShare2ndQuarter", latest.ForecastNonConsolidatedEarningsPerShare2ndQuarter)
+		
+		// 単体翌期予想（第2四半期）
+		validateFinancialValue(t, "NextYearForecastNonConsolidatedNetSales2ndQuarter", latest.NextYearForecastNonConsolidatedNetSales2ndQuarter)
+		validateFinancialValue(t, "NextYearForecastNonConsolidatedOperatingProfit2ndQuarter", latest.NextYearForecastNonConsolidatedOperatingProfit2ndQuarter)
+		validateFinancialValue(t, "NextYearForecastNonConsolidatedOrdinaryProfit2ndQuarter", latest.NextYearForecastNonConsolidatedOrdinaryProfit2ndQuarter)
+		validateFinancialValue(t, "NextYearForecastNonConsolidatedProfit2ndQuarter", latest.NextYearForecastNonConsolidatedProfit2ndQuarter)
+		validateFinancialValue(t, "NextYearForecastNonConsolidatedEarningsPerShare2ndQuarter", latest.NextYearForecastNonConsolidatedEarningsPerShare2ndQuarter)
+		
+		// 単体予想（期末）
+		validateFinancialValue(t, "ForecastNonConsolidatedNetSales", latest.ForecastNonConsolidatedNetSales)
+		validateFinancialValue(t, "ForecastNonConsolidatedOperatingProfit", latest.ForecastNonConsolidatedOperatingProfit)
+		validateFinancialValue(t, "ForecastNonConsolidatedOrdinaryProfit", latest.ForecastNonConsolidatedOrdinaryProfit)
+		validateFinancialValue(t, "ForecastNonConsolidatedProfit", latest.ForecastNonConsolidatedProfit)
+		validateFinancialValue(t, "ForecastNonConsolidatedEarningsPerShare", latest.ForecastNonConsolidatedEarningsPerShare)
+		
+		// 単体翌期予想（期末）
+		validateFinancialValue(t, "NextYearForecastNonConsolidatedNetSales", latest.NextYearForecastNonConsolidatedNetSales)
+		validateFinancialValue(t, "NextYearForecastNonConsolidatedOperatingProfit", latest.NextYearForecastNonConsolidatedOperatingProfit)
+		validateFinancialValue(t, "NextYearForecastNonConsolidatedOrdinaryProfit", latest.NextYearForecastNonConsolidatedOrdinaryProfit)
+		validateFinancialValue(t, "NextYearForecastNonConsolidatedProfit", latest.NextYearForecastNonConsolidatedProfit)
+		validateFinancialValue(t, "NextYearForecastNonConsolidatedEarningsPerShare", latest.NextYearForecastNonConsolidatedEarningsPerShare)
 		
 		t.Logf("Successfully validated all fields for statement: %s", latest.DisclosedDate)
 	})
@@ -212,7 +293,8 @@ func TestStatementsEndpoint(t *testing.T) {
 		// 特定日の財務諸表を取得（過去の営業日を使用）
 		date := getTestDate()
 		
-		statements, err := jq.Statements.GetStatements("", date)
+		// GetStatementsByDateメソッドを使用
+		statements, err := jq.Statements.GetStatementsByDate(date)
 		if err != nil {
 			if isSubscriptionLimited(err) {
 				t.Skip("Skipping due to subscription limitation")


### PR DESCRIPTION
## 概要
- statements APIに不足していた約35個のフィールドを追加
- GitBook文書をMarkdownに変換するgitbook2mdツールを作成
- すべての新規フィールドの包括的なテストと検証を実施

## 詳細

### 1. statements.goに追加した不足フィールド

#### REIT関連フィールド
- `DistributionsPerUnitREIT` - 1口当たり分配金
- `ForecastDistributionsPerUnitREIT` - 1口当たり予想分配金
- `NextYearForecastDistributionsPerUnitREIT` - 翌期1口当たり予想分配金

#### 配当総額フィールド
- `ResultTotalDividendPaidAnnual` - 配当金総額
- `ForecastTotalDividendPaidAnnual` - 予想配当金総額

#### 翌期四半期配当予想（9フィールド）
- `NextYearForecastDividendPerShare1stQuarter`
- `NextYearForecastDividendPerShare2ndQuarter`
- `NextYearForecastDividendPerShare3rdQuarter`
- `NextYearForecastDividendPerShareFiscalYearEnd`
- `NextYearForecastDividendPerShareAnnual`
- `NextYearForecastDistributionsPerUnitREIT`
- `NextYearForecastPayoutRatioAnnual`
- `NextYearForecastTotalDividendPaidAnnual`
- `NextYearForecastDividendPerShareOthers`

#### 翌期四半期業績予想（5フィールド）
- `NextYearForecastNetSales2ndQuarter`
- `NextYearForecastOperatingProfit2ndQuarter`
- `NextYearForecastOrdinaryProfit2ndQuarter`
- `NextYearForecastProfit2ndQuarter`
- `NextYearForecastEarningsPerShare2ndQuarter`

#### その他の重要フィールド
- `AverageNumberOfShares` - 期中平均株式数
- `ChangesBasedOnRevisionsOfAccountingStandard` - 会計基準等の改正に伴う会計方針の変更

#### 単体財務予想フィールド（20フィールド）
- 当期第2四半期予想 5フィールド
- 翌期第2四半期予想 5フィールド
- 当期通期予想 5フィールド
- 翌期通期予想 5フィールド

### 2. 新しいGetStatementsByDateメソッド
特定の日付で財務諸表を取得するメソッドを追加し、既存のGetStatementsメソッドを補完しました。

### 3. gitbook2mdツール
GitBook文書をMarkdownに変換するコマンドラインツールを作成：
- ローカルHTMLファイルと直接URL変換（--urlフラグ）の両方をサポート
- テーブル、コードブロック、見出しを適切に抽出
- GitBook特有のdivベースのテーブル構造に対応
- APIドキュメントを最新に保つのに便利

### 4. ドキュメントの更新
- docs/statements.mdに包括的なAPIエンドポイント情報を追加
- README.mdとCLAUDE.mdにgitbook2mdツールのドキュメントを追加
- .gitignoreを更新してtmpディレクトリを除外

### 5. テスト
- すべての新規フィールドの包括的な単体テストを追加
- 新規フィールドを検証するためのE2Eテストを更新
- curl比較を使用して実際のAPIレスポンスに対してすべてのフィールドを検証

## テスト計画
- [x] 単体テストがパス
- [x] E2Eテストがパス（有効な認証情報を使用）
- [x] EPS計算による データ取得の検証
- [x] ライブラリ出力と直接API呼び出し（curl）の比較
- [x] 実際のREITデータでREIT固有のフィールドをテスト
- [x] 単体財務予想フィールドのテスト

🤖 Generated with [Claude Code](https://claude.ai/code)