### PR TITLE
Add TypeOfDocument type definitions with breaking change

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,7 @@ func TestService_Method(t *testing.T) {
 2. **エラーハンドリング**: 一貫したエラーラップとコンテキスト情報の付与
 3. **型変換**: `types`パッケージのカスタム型を使用してJSONの不整合を処理
 4. **営業日**: 日本の株式市場の営業日を考慮したデータ取得
-5. **定数定義**: 市場区分コード、業種コードなどは定数として定義済み
-   - `MarketPrime`, `MarketStandard`, `MarketGrowth` など
-   - `Sector17Food`, `Sector33IT` など
+5. **定数定義**: 市場区分コード、業種コード、開示書類種別などは定数として定義済み
+   - 市場区分: `MarketPrime`, `MarketStandard`, `MarketGrowth` など
+   - 業種コード: `Sector17Food`, `Sector33IT` など
+   - 開示書類種別: `TypeOfDocumentFYConsolidatedJP`, `TypeOfDocumentFYConsolidatedIFRS` など

--- a/README.md
+++ b/README.md
@@ -136,10 +136,23 @@ growthCompanies, err := jq.Listed.GetListedByMarket(jquants.MarketGrowth, "")
 ```go
 // 最新の財務情報
 statement, err := jq.Statements.GetLatestStatements("7203")
-fmt.Printf("売上高: %.0f円\n", *statement.NetSales)
+if statement.NetSales != nil {
+    fmt.Printf("売上高: %.0f円\n", *statement.NetSales)
+}
 
 // 特定日の財務情報
 statements, err := jq.Statements.GetStatementsByDate("2024-01-15")
+
+// 開示書類種別での絞り込み
+for _, stmt := range statements {
+    // 連結決算のみ処理
+    if stmt.TypeOfDocument.IsConsolidated() {
+        // IFRS採用企業のみ
+        if stmt.TypeOfDocument.GetAccountingStandard() == "IFRS" {
+            fmt.Printf("%s: IFRS採用企業\n", stmt.LocalCode)
+        }
+    }
+}
 ```
 
 ### ページネーション対応

--- a/docs/statements.md
+++ b/docs/statements.md
@@ -34,7 +34,7 @@
 | DisclosedTime | 開示時刻 | HH:MM:SS形式 |
 | LocalCode | 銘柄コード（5桁） | |
 | DisclosureNumber | 開示番号 | APIから出力されるjsonは開示番号で昇順に並んでいる |
-| TypeOfDocument | 開示書類種別 | 例: 3QFinancialStatements_Consolidated_IFRS |
+| TypeOfDocument | 開示書類種別 | 詳細は[開示書類種別一覧](#開示書類種別一覧)を参照 |
 | TypeOfCurrentPeriod | 当会計期間の種類 | [1Q, 2Q, 3Q, 4Q, 5Q, FY] |
 | CurrentPeriodStartDate | 当会計期間開始日 | |
 | CurrentPeriodEndDate | 当会計期間終了日 | |
@@ -244,6 +244,88 @@ headers = {'Authorization': 'Bearer {}'.format(idToken)}
 r = requests.get("https://api.jquants.com/v1/fins/statements?code=86970&date=20230130", headers=headers)
 r.json()
 ```
+
+## 開示書類種別一覧
+
+財務情報APIのTypeOfDocumentフィールドに格納される値の一覧です。
+
+### 決算短信（通期）
+| 書類種別 | 概要 |
+|---------|------|
+| FYFinancialStatements_Consolidated_JP | 決算短信（連結・日本基準） |
+| FYFinancialStatements_Consolidated_US | 決算短信（連結・米国基準） |
+| FYFinancialStatements_NonConsolidated_JP | 決算短信（非連結・日本基準） |
+| FYFinancialStatements_Consolidated_JMIS | 決算短信（連結・ＪＭＩＳ） |
+| FYFinancialStatements_NonConsolidated_IFRS | 決算短信（非連結・ＩＦＲＳ） |
+| FYFinancialStatements_Consolidated_IFRS | 決算短信（連結・ＩＦＲＳ） |
+| FYFinancialStatements_NonConsolidated_Foreign | 決算短信（非連結・外国株） |
+| FYFinancialStatements_Consolidated_Foreign | 決算短信（連結・外国株） |
+| FYFinancialStatements_Consolidated_REIT | 決算短信（REIT） |
+
+### 四半期決算短信
+#### 第1四半期
+| 書類種別 | 概要 |
+|---------|------|
+| 1QFinancialStatements_Consolidated_JP | 第1四半期決算短信（連結・日本基準） |
+| 1QFinancialStatements_Consolidated_US | 第1四半期決算短信（連結・米国基準） |
+| 1QFinancialStatements_NonConsolidated_JP | 第1四半期決算短信（非連結・日本基準） |
+| 1QFinancialStatements_Consolidated_JMIS | 第1四半期決算短信（連結・ＪＭＩＳ） |
+| 1QFinancialStatements_NonConsolidated_IFRS | 第1四半期決算短信（非連結・ＩＦＲＳ） |
+| 1QFinancialStatements_Consolidated_IFRS | 第1四半期決算短信（連結・ＩＦＲＳ） |
+| 1QFinancialStatements_NonConsolidated_Foreign | 第1四半期決算短信（非連結・外国株） |
+| 1QFinancialStatements_Consolidated_Foreign | 第1四半期決算短信（連結・外国株） |
+
+#### 第2四半期
+| 書類種別 | 概要 |
+|---------|------|
+| 2QFinancialStatements_Consolidated_JP | 第2四半期決算短信（連結・日本基準） |
+| 2QFinancialStatements_Consolidated_US | 第2四半期決算短信（連結・米国基準） |
+| 2QFinancialStatements_NonConsolidated_JP | 第2四半期決算短信（非連結・日本基準） |
+| 2QFinancialStatements_Consolidated_JMIS | 第2四半期決算短信（連結・ＪＭＩＳ） |
+| 2QFinancialStatements_NonConsolidated_IFRS | 第2四半期決算短信（非連結・ＩＦＲＳ） |
+| 2QFinancialStatements_Consolidated_IFRS | 第2四半期決算短信（連結・ＩＦＲＳ） |
+| 2QFinancialStatements_NonConsolidated_Foreign | 第2四半期決算短信（非連結・外国株） |
+| 2QFinancialStatements_Consolidated_Foreign | 第2四半期決算短信（連結・外国株） |
+
+#### 第3四半期
+| 書類種別 | 概要 |
+|---------|------|
+| 3QFinancialStatements_Consolidated_JP | 第3四半期決算短信（連結・日本基準） |
+| 3QFinancialStatements_Consolidated_US | 第3四半期決算短信（連結・米国基準） |
+| 3QFinancialStatements_NonConsolidated_JP | 第3四半期決算短信（非連結・日本基準） |
+| 3QFinancialStatements_Consolidated_JMIS | 第3四半期決算短信（連結・ＪＭＩＳ） |
+| 3QFinancialStatements_NonConsolidated_IFRS | 第3四半期決算短信（非連結・ＩＦＲＳ） |
+| 3QFinancialStatements_Consolidated_IFRS | 第3四半期決算短信（連結・ＩＦＲＳ） |
+| 3QFinancialStatements_NonConsolidated_Foreign | 第3四半期決算短信（非連結・外国株） |
+| 3QFinancialStatements_Consolidated_Foreign | 第3四半期決算短信（連結・外国株） |
+
+#### その他の四半期
+| 書類種別 | 概要 |
+|---------|------|
+| OtherPeriodFinancialStatements_Consolidated_JP | その他四半期決算短信（連結・日本基準） |
+| OtherPeriodFinancialStatements_Consolidated_US | その他四半期決算短信（連結・米国基準） |
+| OtherPeriodFinancialStatements_NonConsolidated_JP | その他四半期決算短信（非連結・日本基準） |
+| OtherPeriodFinancialStatements_Consolidated_JMIS | その他四半期決算短信（連結・ＪＭＩＳ） |
+| OtherPeriodFinancialStatements_NonConsolidated_IFRS | その他四半期決算短信（非連結・ＩＦＲＳ） |
+| OtherPeriodFinancialStatements_Consolidated_IFRS | その他四半期決算短信（連結・ＩＦＲＳ） |
+| OtherPeriodFinancialStatements_NonConsolidated_Foreign | その他四半期決算短信（非連結・外国株） |
+| OtherPeriodFinancialStatements_Consolidated_Foreign | その他四半期決算短信（連結・外国株） |
+
+### 予想修正
+| 書類種別 | 概要 |
+|---------|------|
+| DividendForecastRevision | 配当予想の修正 |
+| EarnForecastRevision | 業績予想の修正 |
+| REITDividendForecastRevision | 分配予想の修正（REIT） |
+| REITEarnForecastRevision | 利益予想の修正（REIT） |
+
+### 注記
+- **JP**: 日本基準（JGAAP）
+- **US**: 米国基準（USGAAP）
+- **IFRS**: 国際財務報告基準
+- **JMIS**: 修正国際基準
+- **REIT**: 不動産投資信託
+- **Foreign**: 外国株
 
 ## 関連ドキュメント
 

--- a/example_statements_type_of_document_test.go
+++ b/example_statements_type_of_document_test.go
@@ -1,0 +1,58 @@
+package jquants_test
+
+import (
+	"fmt"
+
+	"github.com/utahta/jquants"
+)
+
+func ExampleTypeOfDocument_usage() {
+	// 定義済みの定数を使用
+	docType := jquants.TypeOfDocumentFYConsolidatedIFRS
+	fmt.Printf("Document type: %s\n", docType)
+	fmt.Printf("Is consolidated: %v\n", docType.IsConsolidated())
+	fmt.Printf("Is annual: %v\n", docType.IsAnnual())
+	fmt.Printf("Accounting standard: %s\n", docType.GetAccountingStandard())
+
+	// Output:
+	// Document type: FYFinancialStatements_Consolidated_IFRS
+	// Is consolidated: true
+	// Is annual: true
+	// Accounting standard: IFRS
+}
+
+func ExampleStatement_TypeOfDocument() {
+	// Statementからの直接使用例
+	stmt := &jquants.Statement{
+		TypeOfDocument: jquants.ParseTypeOfDocument("2QFinancialStatements_Consolidated_JP"),
+	}
+
+	fmt.Printf("Is quarterly: %v\n", stmt.TypeOfDocument.IsQuarterly())
+	fmt.Printf("Period: %s\n", stmt.TypeOfDocument.GetPeriod())
+	fmt.Printf("Accounting standard: %s\n", stmt.TypeOfDocument.GetAccountingStandard())
+
+	// Output:
+	// Is quarterly: true
+	// Period: 2Q
+	// Accounting standard: JP
+}
+
+func ExampleTypeOfDocument_filtering() {
+	// 財務諸表のフィルタリング例
+	statements := []jquants.Statement{
+		{TypeOfDocument: jquants.TypeOfDocumentFYConsolidatedIFRS},
+		{TypeOfDocument: jquants.TypeOfDocumentFYNonConsolidatedJP},
+		{TypeOfDocument: jquants.TypeOfDocumentDividendRevision},
+		{TypeOfDocument: jquants.TypeOfDocument2QConsolidatedJP},
+	}
+
+	// IFRS採用企業の通期決算のみ抽出
+	for _, stmt := range statements {
+		if stmt.TypeOfDocument.IsAnnual() && stmt.TypeOfDocument.GetAccountingStandard() == "IFRS" {
+			fmt.Printf("Found IFRS annual report: %s\n", stmt.TypeOfDocument)
+		}
+	}
+
+	// Output:
+	// Found IFRS annual report: FYFinancialStatements_Consolidated_IFRS
+}

--- a/statements.go
+++ b/statements.go
@@ -30,7 +30,7 @@ type Statement struct {
 	DisclosedTime              string `json:"DisclosedTime"`
 	LocalCode                  string `json:"LocalCode"`
 	DisclosureNumber           string `json:"DisclosureNumber"`
-	TypeOfDocument             string `json:"TypeOfDocument"`
+	TypeOfDocument             TypeOfDocument `json:"TypeOfDocument"`
 	TypeOfCurrentPeriod        string `json:"TypeOfCurrentPeriod"`
 	CurrentPeriodStartDate     string `json:"CurrentPeriodStartDate"`
 	CurrentPeriodEndDate       string `json:"CurrentPeriodEndDate"`
@@ -160,6 +160,7 @@ type Statement struct {
 	NextYearForecastNonConsolidatedProfit           *float64 `json:"NextYearForecastNonConsolidatedProfit"`
 	NextYearForecastNonConsolidatedEarningsPerShare *float64 `json:"NextYearForecastNonConsolidatedEarningsPerShare"`
 }
+
 
 // RawStatement is used for unmarshaling JSON response with mixed types
 type RawStatement struct {
@@ -324,7 +325,7 @@ func (s *StatementsResponse) UnmarshalJSON(data []byte) error {
 			DisclosedTime:              rs.DisclosedTime,
 			LocalCode:                  rs.LocalCode,
 			DisclosureNumber:           rs.DisclosureNumber,
-			TypeOfDocument:             rs.TypeOfDocument,
+			TypeOfDocument:             ParseTypeOfDocument(rs.TypeOfDocument),
 			TypeOfCurrentPeriod:        rs.TypeOfCurrentPeriod,
 			CurrentPeriodStartDate:     rs.CurrentPeriodStartDate,
 			CurrentPeriodEndDate:       rs.CurrentPeriodEndDate,

--- a/statements_type_of_document.go
+++ b/statements_type_of_document.go
@@ -1,0 +1,153 @@
+package jquants
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// TypeOfDocument は財務諸表の開示書類種別を表す型です
+type TypeOfDocument string
+
+// 開示書類種別の定義
+// 財務諸表API (/fins/statements) のTypeOfDocumentフィールドで使用される値です
+const (
+	// 決算短信（通期・連結）
+	TypeOfDocumentFYConsolidatedJP      TypeOfDocument = "FYFinancialStatements_Consolidated_JP"      // 決算短信（連結・日本基準）
+	TypeOfDocumentFYConsolidatedUS      TypeOfDocument = "FYFinancialStatements_Consolidated_US"      // 決算短信（連結・米国基準）
+	TypeOfDocumentFYConsolidatedIFRS    TypeOfDocument = "FYFinancialStatements_Consolidated_IFRS"    // 決算短信（連結・IFRS）
+	TypeOfDocumentFYConsolidatedJMIS    TypeOfDocument = "FYFinancialStatements_Consolidated_JMIS"    // 決算短信（連結・JMIS）
+	TypeOfDocumentFYConsolidatedREIT    TypeOfDocument = "FYFinancialStatements_Consolidated_REIT"    // 決算短信（REIT）
+	TypeOfDocumentFYConsolidatedForeign TypeOfDocument = "FYFinancialStatements_Consolidated_Foreign" // 決算短信（連結・外国株）
+
+	// 決算短信（通期・非連結）
+	TypeOfDocumentFYNonConsolidatedJP      TypeOfDocument = "FYFinancialStatements_NonConsolidated_JP"      // 決算短信（非連結・日本基準）
+	TypeOfDocumentFYNonConsolidatedIFRS    TypeOfDocument = "FYFinancialStatements_NonConsolidated_IFRS"    // 決算短信（非連結・IFRS）
+	TypeOfDocumentFYNonConsolidatedForeign TypeOfDocument = "FYFinancialStatements_NonConsolidated_Foreign" // 決算短信（非連結・外国株）
+
+	// 第1四半期決算短信（連結）
+	TypeOfDocument1QConsolidatedJP   TypeOfDocument = "1QFinancialStatements_Consolidated_JP"   // 第1四半期決算短信（連結・日本基準）
+	TypeOfDocument1QConsolidatedUS   TypeOfDocument = "1QFinancialStatements_Consolidated_US"   // 第1四半期決算短信（連結・米国基準）
+	TypeOfDocument1QConsolidatedIFRS TypeOfDocument = "1QFinancialStatements_Consolidated_IFRS" // 第1四半期決算短信（連結・IFRS）
+
+	// 第2四半期決算短信（連結）
+	TypeOfDocument2QConsolidatedJP   TypeOfDocument = "2QFinancialStatements_Consolidated_JP"   // 第2四半期決算短信（連結・日本基準）
+	TypeOfDocument2QConsolidatedUS   TypeOfDocument = "2QFinancialStatements_Consolidated_US"   // 第2四半期決算短信（連結・米国基準）
+	TypeOfDocument2QConsolidatedIFRS TypeOfDocument = "2QFinancialStatements_Consolidated_IFRS" // 第2四半期決算短信（連結・IFRS）
+
+	// 第3四半期決算短信（連結）
+	TypeOfDocument3QConsolidatedJP   TypeOfDocument = "3QFinancialStatements_Consolidated_JP"   // 第3四半期決算短信（連結・日本基準）
+	TypeOfDocument3QConsolidatedUS   TypeOfDocument = "3QFinancialStatements_Consolidated_US"   // 第3四半期決算短信（連結・米国基準）
+	TypeOfDocument3QConsolidatedIFRS TypeOfDocument = "3QFinancialStatements_Consolidated_IFRS" // 第3四半期決算短信（連結・IFRS）
+
+	// 予想修正
+	TypeOfDocumentDividendRevision     TypeOfDocument = "DividendForecastRevision"     // 配当予想の修正
+	TypeOfDocumentEarningsRevision     TypeOfDocument = "EarnForecastRevision"         // 業績予想の修正
+	TypeOfDocumentREITDividendRevision TypeOfDocument = "REITDividendForecastRevision" // 分配予想の修正（REIT）
+	TypeOfDocumentREITEarningsRevision TypeOfDocument = "REITEarnForecastRevision"     // 利益予想の修正（REIT）
+)
+
+// String はTypeOfDocumentを文字列として返します
+func (t TypeOfDocument) String() string {
+	return string(t)
+}
+
+// IsConsolidated は連結財務諸表かどうかを判定します
+func (t TypeOfDocument) IsConsolidated() bool {
+	s := string(t)
+	return strings.Contains(s, "_Consolidated_") || strings.Contains(s, "_REIT")
+}
+
+// IsNonConsolidated は非連結（単体）財務諸表かどうかを判定します
+func (t TypeOfDocument) IsNonConsolidated() bool {
+	return strings.Contains(string(t), "_NonConsolidated_")
+}
+
+// IsQuarterly は四半期決算短信かどうかを判定します
+func (t TypeOfDocument) IsQuarterly() bool {
+	s := string(t)
+	return strings.Contains(s, "1QFinancial") ||
+		strings.Contains(s, "2QFinancial") ||
+		strings.Contains(s, "3QFinancial") ||
+		strings.Contains(s, "OtherPeriodFinancial")
+}
+
+// IsAnnual は通期決算短信かどうかを判定します
+func (t TypeOfDocument) IsAnnual() bool {
+	return strings.HasPrefix(string(t), "FYFinancial")
+}
+
+// IsForecastRevision は予想修正かどうかを判定します
+func (t TypeOfDocument) IsForecastRevision() bool {
+	s := string(t)
+	return strings.Contains(s, "ForecastRevision")
+}
+
+// IsREIT はREIT関連の書類かどうかを判定します
+func (t TypeOfDocument) IsREIT() bool {
+	return strings.Contains(string(t), "REIT")
+}
+
+// GetAccountingStandard は会計基準を返します
+// 例: "JP" (日本基準), "US" (米国基準), "IFRS" (国際財務報告基準), "JMIS" (修正国際基準), "Foreign" (外国株), "REIT"
+func (t TypeOfDocument) GetAccountingStandard() string {
+	s := string(t)
+	
+	// 予想修正の場合は空文字を返す
+	if t.IsForecastRevision() {
+		return ""
+	}
+	
+	// 最後のアンダースコアの後ろが会計基準
+	parts := strings.Split(s, "_")
+	if len(parts) > 0 {
+		return parts[len(parts)-1]
+	}
+	
+	return ""
+}
+
+// GetPeriod は期間を返します
+// 例: "FY" (通期), "1Q" (第1四半期), "2Q" (第2四半期), "3Q" (第3四半期), "OtherPeriod" (その他)
+func (t TypeOfDocument) GetPeriod() string {
+	s := string(t)
+	
+	// 予想修正の場合は空文字を返す
+	if t.IsForecastRevision() {
+		return ""
+	}
+	
+	if strings.HasPrefix(s, "FY") {
+		return "FY"
+	} else if strings.HasPrefix(s, "1Q") {
+		return "1Q"
+	} else if strings.HasPrefix(s, "2Q") {
+		return "2Q"
+	} else if strings.HasPrefix(s, "3Q") {
+		return "3Q"
+	} else if strings.HasPrefix(s, "OtherPeriod") {
+		return "OtherPeriod"
+	}
+	
+	return ""
+}
+
+// ParseTypeOfDocument は文字列をTypeOfDocument型に変換します
+// 無効な値の場合でもそのまま返します（後方互換性のため）
+func ParseTypeOfDocument(s string) TypeOfDocument {
+	return TypeOfDocument(s)
+}
+
+// UnmarshalJSON はJSONからTypeOfDocumentをデコードします
+func (t *TypeOfDocument) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	*t = TypeOfDocument(s)
+	return nil
+}
+
+// MarshalJSON はTypeOfDocumentをJSONにエンコードします
+func (t TypeOfDocument) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(t))
+}

--- a/statements_type_of_document_test.go
+++ b/statements_type_of_document_test.go
@@ -1,0 +1,376 @@
+package jquants
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestTypeOfDocument_IsConsolidated(t *testing.T) {
+	tests := []struct {
+		name     string
+		doc      TypeOfDocument
+		expected bool
+	}{
+		{
+			name:     "連結・日本基準",
+			doc:      TypeOfDocumentFYConsolidatedJP,
+			expected: true,
+		},
+		{
+			name:     "連結・IFRS",
+			doc:      TypeOfDocument2QConsolidatedIFRS,
+			expected: true,
+		},
+		{
+			name:     "REIT",
+			doc:      TypeOfDocumentFYConsolidatedREIT,
+			expected: true,
+		},
+		{
+			name:     "非連結",
+			doc:      TypeOfDocumentFYNonConsolidatedJP,
+			expected: false,
+		},
+		{
+			name:     "予想修正",
+			doc:      TypeOfDocumentDividendRevision,
+			expected: false,
+		},
+		{
+			name:     "カスタム連結",
+			doc:      ParseTypeOfDocument("OtherPeriodFinancialStatements_Consolidated_JMIS"),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.doc.IsConsolidated(); got != tt.expected {
+				t.Errorf("IsConsolidated() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTypeOfDocument_IsQuarterly(t *testing.T) {
+	tests := []struct {
+		name     string
+		doc      TypeOfDocument
+		expected bool
+	}{
+		{
+			name:     "第1四半期",
+			doc:      TypeOfDocument1QConsolidatedJP,
+			expected: true,
+		},
+		{
+			name:     "第2四半期",
+			doc:      TypeOfDocument2QConsolidatedIFRS,
+			expected: true,
+		},
+		{
+			name:     "第3四半期",
+			doc:      TypeOfDocument3QConsolidatedUS,
+			expected: true,
+		},
+		{
+			name:     "通期",
+			doc:      TypeOfDocumentFYConsolidatedJP,
+			expected: false,
+		},
+		{
+			name:     "その他四半期",
+			doc:      ParseTypeOfDocument("OtherPeriodFinancialStatements_Consolidated_JP"),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.doc.IsQuarterly(); got != tt.expected {
+				t.Errorf("IsQuarterly() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTypeOfDocument_GetAccountingStandard(t *testing.T) {
+	tests := []struct {
+		name     string
+		doc      TypeOfDocument
+		expected string
+	}{
+		{
+			name:     "日本基準",
+			doc:      TypeOfDocumentFYConsolidatedJP,
+			expected: "JP",
+		},
+		{
+			name:     "米国基準",
+			doc:      TypeOfDocument1QConsolidatedUS,
+			expected: "US",
+		},
+		{
+			name:     "IFRS",
+			doc:      TypeOfDocument2QConsolidatedIFRS,
+			expected: "IFRS",
+		},
+		{
+			name:     "JMIS",
+			doc:      ParseTypeOfDocument("3QFinancialStatements_Consolidated_JMIS"),
+			expected: "JMIS",
+		},
+		{
+			name:     "REIT",
+			doc:      TypeOfDocumentFYConsolidatedREIT,
+			expected: "REIT",
+		},
+		{
+			name:     "外国株",
+			doc:      TypeOfDocumentFYConsolidatedForeign,
+			expected: "Foreign",
+		},
+		{
+			name:     "予想修正（会計基準なし）",
+			doc:      TypeOfDocumentDividendRevision,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.doc.GetAccountingStandard(); got != tt.expected {
+				t.Errorf("GetAccountingStandard() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTypeOfDocument_GetPeriod(t *testing.T) {
+	tests := []struct {
+		name     string
+		doc      TypeOfDocument
+		expected string
+	}{
+		{
+			name:     "通期",
+			doc:      TypeOfDocumentFYConsolidatedJP,
+			expected: "FY",
+		},
+		{
+			name:     "第1四半期",
+			doc:      TypeOfDocument1QConsolidatedJP,
+			expected: "1Q",
+		},
+		{
+			name:     "第2四半期",
+			doc:      TypeOfDocument2QConsolidatedIFRS,
+			expected: "2Q",
+		},
+		{
+			name:     "第3四半期",
+			doc:      TypeOfDocument3QConsolidatedUS,
+			expected: "3Q",
+		},
+		{
+			name:     "その他四半期",
+			doc:      ParseTypeOfDocument("OtherPeriodFinancialStatements_Consolidated_JP"),
+			expected: "OtherPeriod",
+		},
+		{
+			name:     "予想修正（期間なし）",
+			doc:      TypeOfDocumentEarningsRevision,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.doc.GetPeriod(); got != tt.expected {
+				t.Errorf("GetPeriod() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTypeOfDocument_IsForecastRevision(t *testing.T) {
+	tests := []struct {
+		name     string
+		doc      TypeOfDocument
+		expected bool
+	}{
+		{
+			name:     "配当予想修正",
+			doc:      TypeOfDocumentDividendRevision,
+			expected: true,
+		},
+		{
+			name:     "業績予想修正",
+			doc:      TypeOfDocumentEarningsRevision,
+			expected: true,
+		},
+		{
+			name:     "REIT分配予想修正",
+			doc:      TypeOfDocumentREITDividendRevision,
+			expected: true,
+		},
+		{
+			name:     "通常の決算短信",
+			doc:      TypeOfDocumentFYConsolidatedJP,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.doc.IsForecastRevision(); got != tt.expected {
+				t.Errorf("IsForecastRevision() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTypeOfDocument_IsREIT(t *testing.T) {
+	tests := []struct {
+		name     string
+		doc      TypeOfDocument
+		expected bool
+	}{
+		{
+			name:     "REIT決算短信",
+			doc:      TypeOfDocumentFYConsolidatedREIT,
+			expected: true,
+		},
+		{
+			name:     "REIT分配予想修正",
+			doc:      TypeOfDocumentREITDividendRevision,
+			expected: true,
+		},
+		{
+			name:     "REIT利益予想修正",
+			doc:      TypeOfDocumentREITEarningsRevision,
+			expected: true,
+		},
+		{
+			name:     "通常の決算短信",
+			doc:      TypeOfDocumentFYConsolidatedJP,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.doc.IsREIT(); got != tt.expected {
+				t.Errorf("IsREIT() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseTypeOfDocument(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  TypeOfDocument
+	}{
+		{
+			name:  "標準的な値",
+			input: "FYFinancialStatements_Consolidated_JP",
+			want:  TypeOfDocumentFYConsolidatedJP,
+		},
+		{
+			name:  "カスタム値",
+			input: "CustomFinancialStatements_Special_Type",
+			want:  TypeOfDocument("CustomFinancialStatements_Special_Type"),
+		},
+		{
+			name:  "空文字",
+			input: "",
+			want:  TypeOfDocument(""),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ParseTypeOfDocument(tt.input); got != tt.want {
+				t.Errorf("ParseTypeOfDocument() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTypeOfDocument_JSON(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  TypeOfDocument
+		json string
+	}{
+		{
+			name: "標準的な値",
+			doc:  TypeOfDocumentFYConsolidatedJP,
+			json: `"FYFinancialStatements_Consolidated_JP"`,
+		},
+		{
+			name: "カスタム値",
+			doc:  TypeOfDocument("CustomType"),
+			json: `"CustomType"`,
+		},
+		{
+			name: "空文字",
+			doc:  TypeOfDocument(""),
+			json: `""`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Marshal
+			got, err := json.Marshal(tt.doc)
+			if err != nil {
+				t.Fatalf("Marshal failed: %v", err)
+			}
+			if string(got) != tt.json {
+				t.Errorf("Marshal() = %s, want %s", got, tt.json)
+			}
+
+			// Unmarshal
+			var doc TypeOfDocument
+			if err := json.Unmarshal([]byte(tt.json), &doc); err != nil {
+				t.Fatalf("Unmarshal failed: %v", err)
+			}
+			if doc != tt.doc {
+				t.Errorf("Unmarshal() = %v, want %v", doc, tt.doc)
+			}
+		})
+	}
+}
+
+func TestStatement_TypeOfDocument_JSON(t *testing.T) {
+	// Statement構造体でのJSON変換テスト
+	stmt := Statement{
+		TypeOfDocument: TypeOfDocumentFYConsolidatedIFRS,
+		LocalCode:      "12345",
+	}
+
+	// Marshal
+	data, err := json.Marshal(stmt)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	// JSONに正しい文字列が含まれているか確認
+	if !strings.Contains(string(data), `"TypeOfDocument":"FYFinancialStatements_Consolidated_IFRS"`) {
+		t.Errorf("JSON does not contain expected TypeOfDocument string: %s", data)
+	}
+
+	// Unmarshal
+	var decoded Statement
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if decoded.TypeOfDocument != TypeOfDocumentFYConsolidatedIFRS {
+		t.Errorf("Unmarshal TypeOfDocument = %v, want %v", decoded.TypeOfDocument, TypeOfDocumentFYConsolidatedIFRS)
+	}
+}


### PR DESCRIPTION
## 概要
財務諸表APIのTypeOfDocumentフィールドに型定義を追加し、直接型として使用するように変更しました。

## 破壊的変更 ⚠️
**Statement.TypeOfDocumentフィールドの型がstringからTypeOfDocumentに変更されました。**

### 移行方法
```go
// Before (v1)
if stmt.TypeOfDocument == "FYFinancialStatements_Consolidated_JP" {
    // ...
}

// After (v2)  
if stmt.TypeOfDocument == jquants.TypeOfDocumentFYConsolidatedJP {
    // ...
}
// または
if stmt.TypeOfDocument.IsConsolidated() && stmt.TypeOfDocument.GetAccountingStandard() == "JP" {
    // ...
}
```

## 主な変更内容

### 1. TypeOfDocument型の定義
主要な開示書類種別の定数を定義：
- 決算短信（通期・四半期）: `TypeOfDocumentFYConsolidatedJP`など
- 予想修正: `TypeOfDocumentDividendRevision`など
- 会計基準別（JP, US, IFRS, JMIS, REIT, Foreign）

### 2. ヘルパーメソッド
```go
// 連結/非連結の判定
stmt.TypeOfDocument.IsConsolidated()
stmt.TypeOfDocument.IsNonConsolidated()

// 期間の判定
stmt.TypeOfDocument.IsQuarterly()
stmt.TypeOfDocument.IsAnnual()

// その他の判定
stmt.TypeOfDocument.IsForecastRevision()
stmt.TypeOfDocument.IsREIT()

// 属性の取得
stmt.TypeOfDocument.GetAccountingStandard() // "JP", "IFRS"など
stmt.TypeOfDocument.GetPeriod() // "FY", "1Q", "2Q"など
```

### 3. JSON対応
- UnmarshalJSON/MarshalJSONを実装
- 既存のJSON形式との互換性を維持

### 4. ドキュメント更新
- docs/statements.mdに開示書類種別一覧を追加
- 全45種類の値と説明を記載

## メリット
- **型安全性**: コンパイル時のチェック
- **IDE補完**: 定数とメソッドの自動補完
- **コード可読性**: 文字列比較より意図が明確
- **将来の拡張性**: 新しいメソッドの追加が容易

## テスト
- [x] TypeOfDocument型の単体テスト
- [x] JSON変換のテスト
- [x] Statement構造体でのテスト
- [x] 既存のテストがすべてパス

🤖 Generated with [Claude Code](https://claude.ai/code)