### PR TITLE
Add session-scoped caching to Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ J-Quants API v2のGo言語クライアントライブラリです。日本の株
 - 📊 包括的な市場データアクセス（株価、財務情報、指数など）
 - 🔐 APIキーによるシンプルな認証
 - 📄 ページネーション対応
+- 🚀 セッション単位のキャッシュ機能（オプション）
 - 🧪 充実したテストカバレッジ
 - 📝 詳細なドキュメント
 
@@ -68,6 +69,29 @@ APIキーは[J-Quantsダッシュボード](https://jpx-jquants.com/)から取�
 ```go
 httpClient := client.NewClient("your-api-key")
 ```
+
+## キャッシュ機能
+
+セッション単位のキャッシュを有効にすると、同じリクエストに対するAPI呼び出しを削減できます。
+
+```go
+// キャッシュを有効化
+httpClient := client.NewClient("your-api-key", client.WithCache())
+
+// または環境変数から
+httpClient, err := client.NewClientFromEnv(client.WithCache())
+
+// キャッシュをクリア
+httpClient.ClearCache()
+
+// キャッシュエントリ数を取得
+size := httpClient.CacheSize()
+```
+
+- キャッシュはGETリクエストのみに適用されます
+- キャッシュキーはリクエストパス（クエリパラメータ含む）で区別されます
+- 同時リクエストの重複排除（singleflight）により効率的に動作します
+- キャッシュはクライアントインスタンスの生存期間のみ有効です
 
 ## 利用可能なAPI
 

--- a/client/client.go
+++ b/client/client.go
@@ -7,7 +7,10 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"sync"
 	"time"
+
+	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -18,63 +21,109 @@ type Client struct {
 	httpClient *http.Client
 	baseURL    string
 	apiKey     string
+	// Cache related fields
+	cache        map[string][]byte
+	cacheEnabled bool
+	mu           sync.RWMutex
+	sf           singleflight.Group
 }
 
-func NewClient(apiKey string) *Client {
-	return &Client{
+// ClientOption is a function type for configuring Client settings.
+type ClientOption func(*Client)
+
+// WithCache enables caching functionality.
+// Cache is only applied to GET requests.
+func WithCache() ClientOption {
+	return func(c *Client) {
+		c.cacheEnabled = true
+		c.cache = make(map[string][]byte)
+	}
+}
+
+// NewClient creates a new Client.
+// Options can be specified to enable features such as caching.
+func NewClient(apiKey string, opts ...ClientOption) *Client {
+	c := &Client{
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
 		baseURL: BaseURL,
 		apiKey:  apiKey,
 	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
 }
 
-// NewClientFromEnv は環境変数 JQUANTS_API_KEY からAPIキーを取得してClientを作成します。
-// 環境変数が設定されていない場合はエラーを返します。
-func NewClientFromEnv() (*Client, error) {
+// NewClientFromEnv creates a Client using the API key from the JQUANTS_API_KEY environment variable.
+// Returns an error if the environment variable is not set.
+// Options can be specified to enable features such as caching.
+func NewClientFromEnv(opts ...ClientOption) (*Client, error) {
 	apiKey := os.Getenv("JQUANTS_API_KEY")
 	if apiKey == "" {
 		return nil, fmt.Errorf("JQUANTS_API_KEY environment variable is not set")
 	}
-	return NewClient(apiKey), nil
+	return NewClient(apiKey, opts...), nil
 }
 
 func (c *Client) DoRequest(method, path string, body interface{}, result interface{}) error {
-	url := c.baseURL + path
+	cacheKey := method + ":" + path
 
-	var reqBody io.Reader
-	if body != nil {
-		jsonBody, err := json.Marshal(body)
-		if err != nil {
-			return fmt.Errorf("failed to marshal request body: %w", err)
+	if method == http.MethodGet && c.cacheEnabled {
+		// Check cache first
+		c.mu.RLock()
+		if cached, ok := c.cache[cacheKey]; ok {
+			c.mu.RUnlock()
+			if result != nil {
+				if err := json.Unmarshal(cached, result); err != nil {
+					return fmt.Errorf("failed to decode cached response: %w", err)
+				}
+			}
+			return nil
 		}
-		reqBody = bytes.NewBuffer(jsonBody)
+		c.mu.RUnlock()
+
+		// Use singleflight to deduplicate concurrent requests for the same key
+		respBody, err, _ := c.sf.Do(cacheKey, func() (interface{}, error) {
+			// Check cache again (another goroutine may have cached it)
+			c.mu.RLock()
+			if cached, ok := c.cache[cacheKey]; ok {
+				c.mu.RUnlock()
+				return cached, nil
+			}
+			c.mu.RUnlock()
+
+			// Perform HTTP request
+			data, err := c.doHTTPRequest(method, path, body)
+			if err != nil {
+				return nil, err
+			}
+
+			// Store in cache
+			c.mu.Lock()
+			c.cache[cacheKey] = data
+			c.mu.Unlock()
+
+			return data, nil
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if result != nil {
+			if err := json.Unmarshal(respBody.([]byte), result); err != nil {
+				return fmt.Errorf("failed to decode response: %w", err)
+			}
+		}
+		return nil
 	}
 
-	req, err := http.NewRequest(method, url, reqBody)
+	// Non-cached request (cache disabled or non-GET method)
+	respBody, err := c.doHTTPRequest(method, path, body)
 	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	if c.apiKey != "" {
-		req.Header.Set("x-api-key", c.apiKey)
-	}
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to send request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read response body: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("API error: status=%d, body=%s", resp.StatusCode, string(respBody))
+		return err
 	}
 
 	if result != nil {
@@ -84,4 +133,65 @@ func (c *Client) DoRequest(method, path string, body interface{}, result interfa
 	}
 
 	return nil
+}
+
+// doHTTPRequest performs the actual HTTP request.
+func (c *Client) doHTTPRequest(method, path string, body interface{}) ([]byte, error) {
+	url := c.baseURL + path
+
+	var reqBody io.Reader
+	if body != nil {
+		jsonBody, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal request body: %w", err)
+		}
+		reqBody = bytes.NewBuffer(jsonBody)
+	}
+
+	req, err := http.NewRequest(method, url, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	if c.apiKey != "" {
+		req.Header.Set("x-api-key", c.apiKey)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API error: status=%d, body=%s", resp.StatusCode, string(respBody))
+	}
+
+	return respBody, nil
+}
+
+// ClearCache clears the cache.
+func (c *Client) ClearCache() {
+	if !c.cacheEnabled {
+		return
+	}
+	c.mu.Lock()
+	c.cache = make(map[string][]byte)
+	c.mu.Unlock()
+}
+
+// CacheSize returns the number of cache entries.
+func (c *Client) CacheSize() int {
+	if !c.cacheEnabled {
+		return 0
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.cache)
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,304 @@
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestNewClient(t *testing.T) {
+	t.Run("without options", func(t *testing.T) {
+		c := NewClient("test-api-key")
+		if c.apiKey != "test-api-key" {
+			t.Errorf("expected apiKey to be 'test-api-key', got '%s'", c.apiKey)
+		}
+		if c.cacheEnabled {
+			t.Error("expected cacheEnabled to be false by default")
+		}
+		if c.cache != nil {
+			t.Error("expected cache to be nil by default")
+		}
+	})
+
+	t.Run("with cache option", func(t *testing.T) {
+		c := NewClient("test-api-key", WithCache())
+		if !c.cacheEnabled {
+			t.Error("expected cacheEnabled to be true")
+		}
+		if c.cache == nil {
+			t.Error("expected cache to be initialized")
+		}
+	})
+}
+
+func TestNewClientFromEnv(t *testing.T) {
+	t.Run("with cache option", func(t *testing.T) {
+		t.Setenv("JQUANTS_API_KEY", "test-api-key")
+		c, err := NewClientFromEnv(WithCache())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !c.cacheEnabled {
+			t.Error("expected cacheEnabled to be true")
+		}
+		if c.cache == nil {
+			t.Error("expected cache to be initialized")
+		}
+	})
+}
+
+func TestClient_DoRequest_CacheHitMiss(t *testing.T) {
+	var callCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "hello"})
+	}))
+	defer server.Close()
+
+	c := NewClient("test-api-key", WithCache())
+	c.baseURL = server.URL
+
+	type response struct {
+		Message string `json:"message"`
+	}
+
+	// First request (cache miss)
+	var resp1 response
+	err := c.DoRequest(http.MethodGet, "/test", nil, &resp1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp1.Message != "hello" {
+		t.Errorf("expected message 'hello', got '%s'", resp1.Message)
+	}
+	if callCount != 1 {
+		t.Errorf("expected 1 call, got %d", callCount)
+	}
+
+	// Second request (cache hit)
+	var resp2 response
+	err = c.DoRequest(http.MethodGet, "/test", nil, &resp2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp2.Message != "hello" {
+		t.Errorf("expected message 'hello', got '%s'", resp2.Message)
+	}
+	if callCount != 1 {
+		t.Errorf("expected 1 call (cached), got %d", callCount)
+	}
+
+	// Different path is a separate cache entry
+	var resp3 response
+	err = c.DoRequest(http.MethodGet, "/test2", nil, &resp3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 calls, got %d", callCount)
+	}
+}
+
+func TestClient_DoRequest_CacheDisabled(t *testing.T) {
+	var callCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "hello"})
+	}))
+	defer server.Close()
+
+	c := NewClient("test-api-key") // no cache
+	c.baseURL = server.URL
+
+	type response struct {
+		Message string `json:"message"`
+	}
+
+	// First request
+	var resp1 response
+	err := c.DoRequest(http.MethodGet, "/test", nil, &resp1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if callCount != 1 {
+		t.Errorf("expected 1 call, got %d", callCount)
+	}
+
+	// Second request (called again since no cache)
+	var resp2 response
+	err = c.DoRequest(http.MethodGet, "/test", nil, &resp2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 calls (no cache), got %d", callCount)
+	}
+}
+
+func TestClient_DoRequest_POSTNotCached(t *testing.T) {
+	var callCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "hello"})
+	}))
+	defer server.Close()
+
+	c := NewClient("test-api-key", WithCache())
+	c.baseURL = server.URL
+
+	type response struct {
+		Message string `json:"message"`
+	}
+
+	// First POST request
+	var resp1 response
+	err := c.DoRequest(http.MethodPost, "/test", nil, &resp1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if callCount != 1 {
+		t.Errorf("expected 1 call, got %d", callCount)
+	}
+
+	// Second POST request (POST is not cached)
+	var resp2 response
+	err = c.DoRequest(http.MethodPost, "/test", nil, &resp2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 calls (POST not cached), got %d", callCount)
+	}
+}
+
+func TestClient_DoRequest_CacheWithQueryParams(t *testing.T) {
+	var callCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"path": r.URL.RequestURI()})
+	}))
+	defer server.Close()
+
+	c := NewClient("test-api-key", WithCache())
+	c.baseURL = server.URL
+
+	type response struct {
+		Path string `json:"path"`
+	}
+
+	// Different query parameters are separate cache entries
+	var resp1 response
+	err := c.DoRequest(http.MethodGet, "/test?code=7203", nil, &resp1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if callCount != 1 {
+		t.Errorf("expected 1 call, got %d", callCount)
+	}
+
+	var resp2 response
+	err = c.DoRequest(http.MethodGet, "/test?code=9984", nil, &resp2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 calls (different query params), got %d", callCount)
+	}
+
+	// Same query parameters result in cache hit
+	var resp3 response
+	err = c.DoRequest(http.MethodGet, "/test?code=7203", nil, &resp3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 calls (cached), got %d", callCount)
+	}
+}
+
+func TestClient_ClearCache(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "hello"})
+	}))
+	defer server.Close()
+
+	c := NewClient("test-api-key", WithCache())
+	c.baseURL = server.URL
+
+	// Populate cache
+	var resp struct{ Message string }
+	_ = c.DoRequest(http.MethodGet, "/test1", nil, &resp)
+	_ = c.DoRequest(http.MethodGet, "/test2", nil, &resp)
+
+	if c.CacheSize() != 2 {
+		t.Errorf("expected cache size 2, got %d", c.CacheSize())
+	}
+
+	// Clear cache
+	c.ClearCache()
+
+	if c.CacheSize() != 0 {
+		t.Errorf("expected cache size 0 after clear, got %d", c.CacheSize())
+	}
+}
+
+func TestClient_CacheSize_Disabled(t *testing.T) {
+	c := NewClient("test-api-key") // no cache
+	if c.CacheSize() != 0 {
+		t.Errorf("expected cache size 0 when disabled, got %d", c.CacheSize())
+	}
+}
+
+func TestClient_ClearCache_Disabled(t *testing.T) {
+	c := NewClient("test-api-key") // no cache
+	// Verify it does not panic
+	c.ClearCache()
+}
+
+func TestClient_DoRequest_ConcurrentAccess(t *testing.T) {
+	var callCount int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "hello"})
+	}))
+	defer server.Close()
+
+	c := NewClient("test-api-key", WithCache())
+	c.baseURL = server.URL
+
+	type response struct {
+		Message string `json:"message"`
+	}
+
+	// Send requests concurrently
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var resp response
+			err := c.DoRequest(http.MethodGet, "/test", nil, &resp)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// With singleflight, concurrent requests for the same key result in only 1 API call
+	if atomic.LoadInt64(&callCount) != 1 {
+		t.Errorf("expected 1 call (singleflight), got %d", callCount)
+	}
+	if c.CacheSize() != 1 {
+		t.Errorf("expected cache size 1, got %d", c.CacheSize())
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/utahta/jquants
 
 go 1.24.0
 
-require golang.org/x/net v0.41.0 // indirect
+require (
+	golang.org/x/net v0.41.0 // indirect
+	golang.org/x/sync v0.19.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 golang.org/x/net v0.41.0 h1:vBTly1HeNPEn3wtREYfy4GZ/NECgw2Cnl+nK6Nz3uvw=
 golang.org/x/net v0.41.0/go.mod h1:B/K4NNqkfmg07DQYrbwvSluqCJOOXwUjeb/5lOisjbA=
+golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
+golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=


### PR DESCRIPTION
## Summary

- Add optional in-memory caching for GET requests to reduce API calls within a session
- Use singleflight to prevent thundering herd problem when multiple goroutines request the same resource concurrently
- Update README.md with cache documentation
- Simplify CLAUDE.md to focus on development guidance

## Changes

- `client/client.go`: Add `WithCache()` option, `ClearCache()`, `CacheSize()` methods
- `client/client_test.go`: Add comprehensive tests for cache functionality
- `README.md`: Add cache feature documentation
- `CLAUDE.md`: Simplify to focus on development guidance

## Usage

```go
// Enable caching
httpClient := client.NewClient("your-api-key", client.WithCache())

// Or with environment variable
httpClient, err := client.NewClientFromEnv(client.WithCache())

// Clear cache
httpClient.ClearCache()

// Get cache size
size := httpClient.CacheSize()
```

## Test plan

- [x] Unit tests for cache hit/miss
- [x] Unit tests for cache disabled (default behavior)
- [x] Unit tests for POST requests not being cached
- [x] Unit tests for query parameter differentiation
- [x] Unit tests for concurrent access with singleflight
- [x] `make test` passes
- [x] `make lint` passes