### PR TITLE
Add missing convenience methods for complete API pattern coverage

### DIFF
--- a/fs_details.go
+++ b/fs_details.go
@@ -146,6 +146,18 @@ func (s *FSDetailsService) GetFSDetailsByDate(date string) ([]FSDetail, error) {
 	return allData, nil
 }
 
+// GetFSDetailsByCodeAndDate は指定銘柄の指定開示日の財務諸表詳細情報を取得します。
+func (s *FSDetailsService) GetFSDetailsByCodeAndDate(code, date string) ([]FSDetail, error) {
+	resp, err := s.GetFSDetails(FSDetailsParams{
+		Code: code,
+		Date: date,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
+}
+
 // IsIFRS は財務諸表がIFRS基準かどうかを判定します。
 func (d *FSDetail) IsIFRS() bool {
 	if standards, ok := d.FS["Accounting standards, DEI"]; ok {

--- a/fs_details_test.go
+++ b/fs_details_test.go
@@ -243,6 +243,45 @@ func TestFSDetailsService_GetFSDetailsByDate(t *testing.T) {
 	}
 }
 
+func TestFSDetailsService_GetFSDetailsByCodeAndDate(t *testing.T) {
+	// Setup
+	mockClient := client.NewMockClient()
+	service := NewFSDetailsService(mockClient)
+
+	// Mock response
+	mockResponse := FSDetailsResponse{
+		Data: []FSDetail{
+			{
+				DiscDate: "2023-01-30",
+				Code:     "86970",
+				DocType:  "3QFinancialStatements_Consolidated_IFRS",
+				FS: map[string]string{
+					"Accounting standards, DEI": "IFRS",
+				},
+			},
+		},
+		PaginationKey: "",
+	}
+	mockClient.SetResponse("GET", "/fins/details?code=86970&date=20230130", mockResponse)
+
+	// Execute
+	data, err := service.GetFSDetailsByCodeAndDate("86970", "20230130")
+
+	// Verify
+	if err != nil {
+		t.Fatalf("GetFSDetailsByCodeAndDate() error = %v", err)
+	}
+	if len(data) != 1 {
+		t.Errorf("GetFSDetailsByCodeAndDate() returned %d items, want 1", len(data))
+	}
+	if data[0].Code != "86970" {
+		t.Errorf("GetFSDetailsByCodeAndDate() returned code %v, want 86970", data[0].Code)
+	}
+	if data[0].DiscDate != "2023-01-30" {
+		t.Errorf("GetFSDetailsByCodeAndDate() returned date %v, want 2023-01-30", data[0].DiscDate)
+	}
+}
+
 func TestFSDetail_AccountingStandardsMethods(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/indices.go
+++ b/indices.go
@@ -3,7 +3,6 @@ package jquants
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/utahta/jquants/client"
 	"github.com/utahta/jquants/types"
@@ -127,31 +126,63 @@ func (s *IndicesService) GetIndices(params IndicesParams) (*IndicesResponse, err
 	return &resp, nil
 }
 
-// GetIndicesByCode は指定指数の過去N日間のデータを取得します。
+// GetIndicesByCode は指定指数の全期間のデータを取得します。
 // ページネーションを使用して全データを取得します。
-func (s *IndicesService) GetIndicesByCode(code string, days int) ([]Index, error) {
-	to := time.Now()
-	from := to.AddDate(0, 0, -days)
-
+func (s *IndicesService) GetIndicesByCode(code string) ([]Index, error) {
 	var allIndices []Index
 	paginationKey := ""
 
 	for {
-		params := IndicesParams{
+		resp, err := s.GetIndices(IndicesParams{
 			Code:          code,
-			From:          from.Format("20060102"),
-			To:            to.Format("20060102"),
 			PaginationKey: paginationKey,
-		}
-
-		resp, err := s.GetIndices(params)
+		})
 		if err != nil {
 			return nil, err
 		}
 
 		allIndices = append(allIndices, resp.Data...)
 
-		// ページネーションキーがなければ終了
+		if resp.PaginationKey == "" {
+			break
+		}
+		paginationKey = resp.PaginationKey
+	}
+
+	return allIndices, nil
+}
+
+// GetIndicesByCodeAndDate は指定指数の指定日のデータを取得します。
+func (s *IndicesService) GetIndicesByCodeAndDate(code, date string) ([]Index, error) {
+	resp, err := s.GetIndices(IndicesParams{
+		Code: code,
+		Date: date,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
+}
+
+// GetIndicesByCodeAndDateRange は指定指数の指定期間のデータを取得します。
+// ページネーションを使用して全データを取得します。
+func (s *IndicesService) GetIndicesByCodeAndDateRange(code, from, to string) ([]Index, error) {
+	var allIndices []Index
+	paginationKey := ""
+
+	for {
+		resp, err := s.GetIndices(IndicesParams{
+			Code:          code,
+			From:          from,
+			To:            to,
+			PaginationKey: paginationKey,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		allIndices = append(allIndices, resp.Data...)
+
 		if resp.PaginationKey == "" {
 			break
 		}
@@ -162,7 +193,7 @@ func (s *IndicesService) GetIndicesByCode(code string, days int) ([]Index, error
 }
 
 // GetIndicesByDate は指定日の全指数データを取得します。
-// ページネーションを使用して大量データを分割取得します。
+// ページネーションを使用して全データを取得します。
 func (s *IndicesService) GetIndicesByDate(date string) ([]Index, error) {
 	var allIndices []Index
 	paginationKey := ""
@@ -214,24 +245,24 @@ const (
 	IndexJPXPrime150 = "0503" // JPXプライム150指数
 )
 
-// GetTOPIX はTOPIXのデータを取得します。
-func (s *IndicesService) GetTOPIX(days int) ([]Index, error) {
-	return s.GetIndicesByCode(IndexTOPIX, days)
+// GetTOPIX はTOPIXの全期間データを取得します。
+func (s *IndicesService) GetTOPIX() ([]Index, error) {
+	return s.GetIndicesByCode(IndexTOPIX)
 }
 
-// GetTOPIXCore30 はTOPIX Core30のデータを取得します。
-func (s *IndicesService) GetTOPIXCore30(days int) ([]Index, error) {
-	return s.GetIndicesByCode(IndexTOPIXCore30, days)
+// GetTOPIXCore30 はTOPIX Core30の全期間データを取得します。
+func (s *IndicesService) GetTOPIXCore30() ([]Index, error) {
+	return s.GetIndicesByCode(IndexTOPIXCore30)
 }
 
-// GetPrimeMarketIndex は東証プライム市場指数のデータを取得します。
-func (s *IndicesService) GetPrimeMarketIndex(days int) ([]Index, error) {
-	return s.GetIndicesByCode(IndexPrime, days)
+// GetPrimeMarketIndex は東証プライム市場指数の全期間データを取得します。
+func (s *IndicesService) GetPrimeMarketIndex() ([]Index, error) {
+	return s.GetIndicesByCode(IndexPrime)
 }
 
-// GetREIT はREIT指数のデータを取得します。
-func (s *IndicesService) GetREIT(days int) ([]Index, error) {
-	return s.GetIndicesByCode(IndexREIT, days)
+// GetREIT はREIT指数の全期間データを取得します。
+func (s *IndicesService) GetREIT() ([]Index, error) {
+	return s.GetIndicesByCode(IndexREIT)
 }
 
 // 業種別指数コード（東証33業種）
@@ -271,7 +302,7 @@ const (
 	IndexSectorServices     = "0060" // サービス業
 )
 
-// GetSectorIndex は指定した業種別指数のデータを取得します。
-func (s *IndicesService) GetSectorIndex(sectorCode string, days int) ([]Index, error) {
-	return s.GetIndicesByCode(sectorCode, days)
+// GetSectorIndex は指定した業種別指数の全期間データを取得します。
+func (s *IndicesService) GetSectorIndex(sectorCode string) ([]Index, error) {
+	return s.GetIndicesByCode(sectorCode)
 }

--- a/short_selling.go
+++ b/short_selling.go
@@ -218,6 +218,18 @@ func (s *ShortSellingService) GetShortSellingBySectorAndDateRange(sector33Code, 
 	return allData, nil
 }
 
+// GetShortSellingBySectorAndDate は指定業種の指定日の空売り比率を取得します。
+func (s *ShortSellingService) GetShortSellingBySectorAndDate(sector33Code, date string) ([]ShortSelling, error) {
+	resp, err := s.GetShortSelling(ShortSellingParams{
+		Sector33Code: sector33Code,
+		Date:         date,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
+}
+
 // GetTotalShortSellingValue は空売り合計金額を計算します。
 func (ss *ShortSelling) GetTotalShortSellingValue() float64 {
 	return ss.ShrtWithResVa + ss.ShrtNoResVa

--- a/short_selling_positions.go
+++ b/short_selling_positions.go
@@ -303,6 +303,62 @@ func (s *ShortSellingPositionsService) GetShortSellingPositionsByCodeAndDateRang
 	return allData, nil
 }
 
+// GetShortSellingPositionsByCodeAndDisclosedDate は指定銘柄の指定公表日の空売り残高報告を取得します。
+func (s *ShortSellingPositionsService) GetShortSellingPositionsByCodeAndDisclosedDate(code, disclosedDate string) ([]ShortSellingPosition, error) {
+	var allData []ShortSellingPosition
+	paginationKey := ""
+
+	for {
+		params := ShortSellingPositionsParams{
+			Code:          code,
+			DisclosedDate: disclosedDate,
+			PaginationKey: paginationKey,
+		}
+
+		resp, err := s.GetShortSellingPositions(params)
+		if err != nil {
+			return nil, err
+		}
+
+		allData = append(allData, resp.Data...)
+
+		if resp.PaginationKey == "" {
+			break
+		}
+		paginationKey = resp.PaginationKey
+	}
+
+	return allData, nil
+}
+
+// GetShortSellingPositionsByCodeAndCalculatedDate は指定銘柄の指定計算日の空売り残高報告を取得します。
+func (s *ShortSellingPositionsService) GetShortSellingPositionsByCodeAndCalculatedDate(code, calculatedDate string) ([]ShortSellingPosition, error) {
+	var allData []ShortSellingPosition
+	paginationKey := ""
+
+	for {
+		params := ShortSellingPositionsParams{
+			Code:           code,
+			CalculatedDate: calculatedDate,
+			PaginationKey:  paginationKey,
+		}
+
+		resp, err := s.GetShortSellingPositions(params)
+		if err != nil {
+			return nil, err
+		}
+
+		allData = append(allData, resp.Data...)
+
+		if resp.PaginationKey == "" {
+			break
+		}
+		paginationKey = resp.PaginationKey
+	}
+
+	return allData, nil
+}
+
 // GetPositionChange は前回報告からの残高変化を計算します（株数）。
 func (ssp *ShortSellingPosition) GetPositionChange() float64 {
 	// 前回報告時の残高割合から株数を逆算

--- a/short_selling_positions_test.go
+++ b/short_selling_positions_test.go
@@ -328,6 +328,84 @@ func TestShortSellingPositionsService_GetShortSellingPositionsByCodeAndDateRange
 	}
 }
 
+func TestShortSellingPositionsService_GetShortSellingPositionsByCodeAndDisclosedDate(t *testing.T) {
+	// Setup
+	mockClient := client.NewMockClient()
+	service := NewShortSellingPositionsService(mockClient)
+
+	// Mock response
+	mockResponse := ShortSellingPositionsResponse{
+		Data: []ShortSellingPosition{
+			{
+				DiscDate:      "2024-08-01",
+				CalcDate:      "2024-07-31",
+				Code:          "86970",
+				SSName:        "ABC Investment Management",
+				ShrtPosToSO:   0.0153,
+				ShrtPosShares: 520000,
+			},
+		},
+		PaginationKey: "",
+	}
+	mockClient.SetResponse("GET", "/markets/short-sale-report?code=86970&disc_date=20240801", mockResponse)
+
+	// Execute
+	data, err := service.GetShortSellingPositionsByCodeAndDisclosedDate("86970", "20240801")
+
+	// Verify
+	if err != nil {
+		t.Fatalf("GetShortSellingPositionsByCodeAndDisclosedDate() error = %v", err)
+	}
+	if len(data) != 1 {
+		t.Errorf("GetShortSellingPositionsByCodeAndDisclosedDate() returned %d items, want 1", len(data))
+	}
+	if data[0].Code != "86970" {
+		t.Errorf("GetShortSellingPositionsByCodeAndDisclosedDate() returned code %v, want 86970", data[0].Code)
+	}
+	if data[0].DiscDate != "2024-08-01" {
+		t.Errorf("GetShortSellingPositionsByCodeAndDisclosedDate() returned disc_date %v, want 2024-08-01", data[0].DiscDate)
+	}
+}
+
+func TestShortSellingPositionsService_GetShortSellingPositionsByCodeAndCalculatedDate(t *testing.T) {
+	// Setup
+	mockClient := client.NewMockClient()
+	service := NewShortSellingPositionsService(mockClient)
+
+	// Mock response
+	mockResponse := ShortSellingPositionsResponse{
+		Data: []ShortSellingPosition{
+			{
+				DiscDate:      "2024-08-01",
+				CalcDate:      "2024-07-31",
+				Code:          "86970",
+				SSName:        "ABC Investment Management",
+				ShrtPosToSO:   0.0153,
+				ShrtPosShares: 520000,
+			},
+		},
+		PaginationKey: "",
+	}
+	mockClient.SetResponse("GET", "/markets/short-sale-report?code=86970&calc_date=20240731", mockResponse)
+
+	// Execute
+	data, err := service.GetShortSellingPositionsByCodeAndCalculatedDate("86970", "20240731")
+
+	// Verify
+	if err != nil {
+		t.Fatalf("GetShortSellingPositionsByCodeAndCalculatedDate() error = %v", err)
+	}
+	if len(data) != 1 {
+		t.Errorf("GetShortSellingPositionsByCodeAndCalculatedDate() returned %d items, want 1", len(data))
+	}
+	if data[0].Code != "86970" {
+		t.Errorf("GetShortSellingPositionsByCodeAndCalculatedDate() returned code %v, want 86970", data[0].Code)
+	}
+	if data[0].CalcDate != "2024-07-31" {
+		t.Errorf("GetShortSellingPositionsByCodeAndCalculatedDate() returned calc_date %v, want 2024-07-31", data[0].CalcDate)
+	}
+}
+
 func TestShortSellingPosition_GetPositionChange(t *testing.T) {
 	position := ShortSellingPosition{
 		ShrtPosToSO:   0.0053,

--- a/short_selling_test.go
+++ b/short_selling_test.go
@@ -253,6 +253,44 @@ func TestShortSellingService_GetShortSellingBySectorAndDateRange(t *testing.T) {
 	}
 }
 
+func TestShortSellingService_GetShortSellingBySectorAndDate(t *testing.T) {
+	// Setup
+	mockClient := client.NewMockClient()
+	service := NewShortSellingService(mockClient)
+
+	// Mock response
+	mockResponse := ShortSellingResponse{
+		Data: []ShortSelling{
+			{
+				Date:          "2022-10-25",
+				S33:           "0050",
+				SellExShortVa: 1333126400.0,
+				ShrtWithResVa: 787355200.0,
+				ShrtNoResVa:   149084300.0,
+			},
+		},
+		PaginationKey: "",
+	}
+	mockClient.SetResponse("GET", "/markets/short-ratio?s33=0050&date=20221025", mockResponse)
+
+	// Execute
+	data, err := service.GetShortSellingBySectorAndDate("0050", "20221025")
+
+	// Verify
+	if err != nil {
+		t.Fatalf("GetShortSellingBySectorAndDate() error = %v", err)
+	}
+	if len(data) != 1 {
+		t.Errorf("GetShortSellingBySectorAndDate() returned %d items, want 1", len(data))
+	}
+	if data[0].S33 != "0050" {
+		t.Errorf("GetShortSellingBySectorAndDate() returned s33 %v, want 0050", data[0].S33)
+	}
+	if data[0].Date != "2022-10-25" {
+		t.Errorf("GetShortSellingBySectorAndDate() returned date %v, want 2022-10-25", data[0].Date)
+	}
+}
+
 func TestShortSelling_GetTotalShortSellingValue(t *testing.T) {
 	data := ShortSelling{
 		ShrtWithResVa: 787355200.0,

--- a/test/e2e/daily_quotes_test.go
+++ b/test/e2e/daily_quotes_test.go
@@ -248,8 +248,8 @@ func TestDailyQuotesEndpoint(t *testing.T) {
 	})
 
 	t.Run("GetDailyQuotesByCode_Convenience", func(t *testing.T) {
-		// 便利メソッドのテスト（過去30日分）
-		quotes, err := jq.Quotes.GetDailyQuotesByCode("7203", 30)
+		// 便利メソッドのテスト（全期間）
+		quotes, err := jq.Quotes.GetDailyQuotesByCode("7203")
 		if err != nil {
 			if isSubscriptionLimited(err) {
 				t.Skip("Skipping due to subscription limitation")

--- a/test/e2e/indices_test.go
+++ b/test/e2e/indices_test.go
@@ -178,7 +178,7 @@ func TestIndicesEndpoint(t *testing.T) {
 
 	t.Run("GetTOPIXCore30", func(t *testing.T) {
 		// TOPIX Core30の便利メソッドテスト
-		indices, err := jq.Indices.GetTOPIXCore30(30) // 過去30日分
+		indices, err := jq.Indices.GetTOPIXCore30()
 		if err != nil {
 			if isSubscriptionLimited(err) {
 				t.Skip("Skipping due to subscription limitation")
@@ -217,7 +217,7 @@ func TestIndicesEndpoint(t *testing.T) {
 
 	t.Run("GetTOPIX", func(t *testing.T) {
 		// TOPIXの便利メソッドテスト
-		indices, err := jq.Indices.GetTOPIX(30) // 過去30日分
+		indices, err := jq.Indices.GetTOPIX()
 		if err != nil {
 			if isSubscriptionLimited(err) {
 				t.Skip("Skipping due to subscription limitation")

--- a/test/e2e/listed_test.go
+++ b/test/e2e/listed_test.go
@@ -9,9 +9,9 @@ import (
 
 // TestListedEndpoint は/equities/masterエンドポイントの完全なテスト
 func TestListedEndpoint(t *testing.T) {
-	t.Run("GetInfo_All", func(t *testing.T) {
+	t.Run("GetAllListedInfo", func(t *testing.T) {
 		// 全ての上場企業情報を取得
-		companies, err := jq.Listed.GetListedInfo("", "")
+		companies, err := jq.Listed.GetAllListedInfo()
 		if err != nil {
 			if isSubscriptionLimited(err) {
 				t.Skip("Skipping due to subscription limitation")
@@ -86,19 +86,21 @@ func TestListedEndpoint(t *testing.T) {
 		}
 	})
 
-	t.Run("GetInfoByCode_ValidCode", func(t *testing.T) {
+	t.Run("GetListedInfoByCode", func(t *testing.T) {
 		// 特定の銘柄コードで企業情報を取得（トヨタ自動車）
-		company, err := jq.Listed.GetCompanyInfo("7203")
+		infos, err := jq.Listed.GetListedInfoByCode("7203")
 		if err != nil {
 			if isSubscriptionLimited(err) {
 				t.Skip("Skipping due to subscription limitation")
 			}
-			t.Fatalf("Failed to get company info for code 7203: %v", err)
+			t.Fatalf("Failed to get listed info for code 7203: %v", err)
 		}
 
-		if company == nil {
-			t.Fatal("Company info is nil for code 7203")
+		if len(infos) == 0 {
+			t.Fatal("No listed info for code 7203")
 		}
+
+		company := infos[0]
 
 		// トヨタ自動車の詳細検証
 		if company.Code != "72030" && company.Code != "7203" {
@@ -129,9 +131,9 @@ func TestListedEndpoint(t *testing.T) {
 		}
 	})
 
-	t.Run("GetInfoByCode_InvalidCode", func(t *testing.T) {
+	t.Run("GetListedInfoByCode_InvalidCode", func(t *testing.T) {
 		// 存在しない銘柄コードでのテスト
-		company, err := jq.Listed.GetCompanyInfo("99999")
+		infos, err := jq.Listed.GetListedInfoByCode("99999")
 		if err != nil {
 			if isSubscriptionLimited(err) {
 				t.Skip("Skipping due to subscription limitation")
@@ -141,14 +143,14 @@ func TestListedEndpoint(t *testing.T) {
 			return
 		}
 
-		if company != nil {
-			t.Error("Expected nil company for invalid code 99999")
+		if len(infos) > 0 {
+			t.Error("Expected no data for invalid code 99999")
 		}
 	})
 
-	t.Run("GetInfo_MarketSegments", func(t *testing.T) {
+	t.Run("GetAllListedInfo_MarketSegments", func(t *testing.T) {
 		// 全企業の市場セグメント分析
-		companies, err := jq.Listed.GetListedInfo("", "")
+		companies, err := jq.Listed.GetAllListedInfo()
 		if err != nil {
 			if isSubscriptionLimited(err) {
 				t.Skip("Skipping due to subscription limitation")
@@ -180,9 +182,9 @@ func TestListedEndpoint(t *testing.T) {
 		}
 	})
 
-	t.Run("GetInfo_SectorAnalysis", func(t *testing.T) {
+	t.Run("GetAllListedInfo_SectorAnalysis", func(t *testing.T) {
 		// 業種別分析
-		companies, err := jq.Listed.GetListedInfo("", "")
+		companies, err := jq.Listed.GetAllListedInfo()
 		if err != nil {
 			if isSubscriptionLimited(err) {
 				t.Skip("Skipping due to subscription limitation")
@@ -219,9 +221,9 @@ func TestListedEndpoint(t *testing.T) {
 		}
 	})
 
-	t.Run("GetInfo_CodeValidation", func(t *testing.T) {
+	t.Run("GetAllListedInfo_CodeValidation", func(t *testing.T) {
 		// 銘柄コードの形式検証
-		companies, err := jq.Listed.GetListedInfo("", "")
+		companies, err := jq.Listed.GetAllListedInfo()
 		if err != nil {
 			if isSubscriptionLimited(err) {
 				t.Skip("Skipping due to subscription limitation")

--- a/test/e2e/statements_test.go
+++ b/test/e2e/statements_test.go
@@ -11,7 +11,7 @@ import (
 func TestStatementsEndpoint(t *testing.T) {
 	t.Run("GetStatements_ByCode", func(t *testing.T) {
 		// トヨタ自動車(7203)の財務諸表を取得
-		statements, err := jq.Statements.GetStatements("7203", "")
+		statements, err := jq.Statements.GetAllStatementsByCode("7203")
 		if err != nil {
 			if isSubscriptionLimited(err) {
 				t.Skip("Skipping due to subscription limitation")
@@ -260,7 +260,7 @@ func TestStatementsEndpoint(t *testing.T) {
 
 	t.Run("GetStatements_Historical", func(t *testing.T) {
 		// 複数の履歴データ取得のテスト
-		statements, err := jq.Statements.GetStatements("7203", "")
+		statements, err := jq.Statements.GetAllStatementsByCode("7203")
 		if err != nil {
 			if isSubscriptionLimited(err) {
 				t.Skip("Skipping due to subscription limitation")

--- a/trades_spec.go
+++ b/trades_spec.go
@@ -235,6 +235,36 @@ func (s *TradesSpecService) GetAllTradesSpec() ([]TradesSpec, error) {
 	return allTradesSpec, nil
 }
 
+// GetTradesSpecBySectionAndDateRange は指定セクション・期間の投資部門別情報を取得します。
+// ページネーションを使用して全データを取得します。
+func (s *TradesSpecService) GetTradesSpecBySectionAndDateRange(section, from, to string) ([]TradesSpec, error) {
+	var allTradesSpec []TradesSpec
+	paginationKey := ""
+
+	for {
+		params := TradesSpecParams{
+			Section:       section,
+			From:          from,
+			To:            to,
+			PaginationKey: paginationKey,
+		}
+
+		resp, err := s.GetTradesSpec(params)
+		if err != nil {
+			return nil, err
+		}
+
+		allTradesSpec = append(allTradesSpec, resp.Data...)
+
+		if resp.PaginationKey == "" {
+			break
+		}
+		paginationKey = resp.PaginationKey
+	}
+
+	return allTradesSpec, nil
+}
+
 // IsBuyerDominant は買い手が優勢かどうかを判定します（差引がプラス）。
 func (ts *TradesSpec) IsBuyerDominant(investorType string) bool {
 	switch investorType {

--- a/trades_spec_test.go
+++ b/trades_spec_test.go
@@ -218,6 +218,54 @@ func TestTradesSpecService_GetTradesSpecBySection(t *testing.T) {
 	}
 }
 
+func TestTradesSpecService_GetTradesSpecBySectionAndDateRange(t *testing.T) {
+	// Setup
+	mockClient := client.NewMockClient()
+	service := NewTradesSpecService(mockClient)
+
+	// Mock response
+	mockResponse := TradesSpecResponse{
+		Data: []TradesSpec{
+			{
+				PubDate: "2023-04-07",
+				StDate:  "2023-03-27",
+				EnDate:  "2023-03-31",
+				Section: "TSEPrime",
+				TotBal:  1000000,
+				FrgnBal: 500000,
+				IndBal:  -200000,
+			},
+			{
+				PubDate: "2023-04-14",
+				StDate:  "2023-04-03",
+				EnDate:  "2023-04-07",
+				Section: "TSEPrime",
+				TotBal:  800000,
+				FrgnBal: 300000,
+				IndBal:  -100000,
+			},
+		},
+		PaginationKey: "",
+	}
+	mockClient.SetResponse("GET", "/equities/investor-types?section=TSEPrime&from=20230324&to=20230403", mockResponse)
+
+	// Execute
+	tradesSpec, err := service.GetTradesSpecBySectionAndDateRange("TSEPrime", "20230324", "20230403")
+
+	// Verify
+	if err != nil {
+		t.Fatalf("GetTradesSpecBySectionAndDateRange() error = %v", err)
+	}
+	if len(tradesSpec) != 2 {
+		t.Errorf("GetTradesSpecBySectionAndDateRange() returned %d items, want 2", len(tradesSpec))
+	}
+	for _, ts := range tradesSpec {
+		if ts.Section != "TSEPrime" {
+			t.Errorf("GetTradesSpecBySectionAndDateRange() returned section %v, want TSEPrime", ts.Section)
+		}
+	}
+}
+
 func TestTradesSpec_IsBuyerDominant(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/trading_calendar.go
+++ b/trading_calendar.go
@@ -76,6 +76,39 @@ func (s *TradingCalendarService) GetTradingCalendar(params TradingCalendarParams
 	return &resp, nil
 }
 
+// GetAllTradingCalendar は全期間・全区分の取引カレンダーを取得します。
+func (s *TradingCalendarService) GetAllTradingCalendar() ([]TradingCalendar, error) {
+	resp, err := s.GetTradingCalendar(TradingCalendarParams{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
+}
+
+// GetTradingCalendarByHolidayDivision は指定した休日区分の全期間の取引カレンダーを取得します。
+func (s *TradingCalendarService) GetTradingCalendarByHolidayDivision(holDiv string) ([]TradingCalendar, error) {
+	resp, err := s.GetTradingCalendar(TradingCalendarParams{
+		HolidayDivision: holDiv,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
+}
+
+// GetTradingCalendarByHolidayDivisionAndDateRange は指定した休日区分・期間の取引カレンダーを取得します。
+func (s *TradingCalendarService) GetTradingCalendarByHolidayDivisionAndDateRange(holDiv, from, to string) ([]TradingCalendar, error) {
+	resp, err := s.GetTradingCalendar(TradingCalendarParams{
+		HolidayDivision: holDiv,
+		From:            from,
+		To:              to,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
+}
+
 // GetTradingCalendarByDateRange は指定した期間の取引カレンダーを取得します。
 func (s *TradingCalendarService) GetTradingCalendarByDateRange(from, to string) ([]TradingCalendar, error) {
 	resp, err := s.GetTradingCalendar(TradingCalendarParams{

--- a/trading_calendar_test.go
+++ b/trading_calendar_test.go
@@ -86,6 +86,95 @@ func TestTradingCalendarService_GetTradingCalendar(t *testing.T) {
 	}
 }
 
+func TestTradingCalendarService_GetAllTradingCalendar(t *testing.T) {
+	// Setup
+	mockClient := client.NewMockClient()
+	service := NewTradingCalendarService(mockClient)
+
+	// Mock response
+	mockResponse := TradingCalendarResponse{
+		Data: []TradingCalendar{
+			{Date: "2024-01-01", HolDiv: "0"},
+			{Date: "2024-01-02", HolDiv: "1"},
+			{Date: "2024-01-03", HolDiv: "1"},
+		},
+	}
+	mockClient.SetResponse("GET", "/markets/calendar", mockResponse)
+
+	// Execute
+	data, err := service.GetAllTradingCalendar()
+
+	// Verify
+	if err != nil {
+		t.Fatalf("GetAllTradingCalendar() error = %v", err)
+	}
+	if len(data) != 3 {
+		t.Errorf("GetAllTradingCalendar() returned %d items, want 3", len(data))
+	}
+}
+
+func TestTradingCalendarService_GetTradingCalendarByHolidayDivision(t *testing.T) {
+	// Setup
+	mockClient := client.NewMockClient()
+	service := NewTradingCalendarService(mockClient)
+
+	// Mock response
+	mockResponse := TradingCalendarResponse{
+		Data: []TradingCalendar{
+			{Date: "2024-01-02", HolDiv: "1"},
+			{Date: "2024-01-03", HolDiv: "1"},
+		},
+	}
+	mockClient.SetResponse("GET", "/markets/calendar?hol_div=1", mockResponse)
+
+	// Execute
+	data, err := service.GetTradingCalendarByHolidayDivision("1")
+
+	// Verify
+	if err != nil {
+		t.Fatalf("GetTradingCalendarByHolidayDivision() error = %v", err)
+	}
+	if len(data) != 2 {
+		t.Errorf("GetTradingCalendarByHolidayDivision() returned %d items, want 2", len(data))
+	}
+	for _, day := range data {
+		if day.HolDiv != "1" {
+			t.Errorf("GetTradingCalendarByHolidayDivision() returned HolDiv %v, want 1", day.HolDiv)
+		}
+	}
+}
+
+func TestTradingCalendarService_GetTradingCalendarByHolidayDivisionAndDateRange(t *testing.T) {
+	// Setup
+	mockClient := client.NewMockClient()
+	service := NewTradingCalendarService(mockClient)
+
+	// Mock response
+	mockResponse := TradingCalendarResponse{
+		Data: []TradingCalendar{
+			{Date: "2024-01-02", HolDiv: "1"},
+			{Date: "2024-01-03", HolDiv: "1"},
+		},
+	}
+	mockClient.SetResponse("GET", "/markets/calendar?hol_div=1&from=20240101&to=20240131", mockResponse)
+
+	// Execute
+	data, err := service.GetTradingCalendarByHolidayDivisionAndDateRange("1", "20240101", "20240131")
+
+	// Verify
+	if err != nil {
+		t.Fatalf("GetTradingCalendarByHolidayDivisionAndDateRange() error = %v", err)
+	}
+	if len(data) != 2 {
+		t.Errorf("GetTradingCalendarByHolidayDivisionAndDateRange() returned %d items, want 2", len(data))
+	}
+	for _, day := range data {
+		if day.HolDiv != "1" {
+			t.Errorf("GetTradingCalendarByHolidayDivisionAndDateRange() returned HolDiv %v, want 1", day.HolDiv)
+		}
+	}
+}
+
 func TestTradingCalendarService_GetTradingCalendarByDateRange(t *testing.T) {
 	// Setup
 	mockClient := client.NewMockClient()

--- a/weekly_margin_interest.go
+++ b/weekly_margin_interest.go
@@ -243,6 +243,18 @@ func (s *WeeklyMarginInterestService) GetWeeklyMarginInterestByCodeAndDateRange(
 	return allData, nil
 }
 
+// GetWeeklyMarginInterestByCodeAndDate は指定銘柄の指定公表日の信用取引週末残高を取得します。
+func (s *WeeklyMarginInterestService) GetWeeklyMarginInterestByCodeAndDate(code, date string) ([]WeeklyMarginInterest, error) {
+	resp, err := s.GetWeeklyMarginInterest(WeeklyMarginInterestParams{
+		Code: code,
+		Date: date,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
+}
+
 // IsCredit は信用銘柄かどうかを判定します。
 func (wmi *WeeklyMarginInterest) IsCredit() bool {
 	return wmi.IssType == IssueTypeCredit

--- a/weekly_margin_interest_test.go
+++ b/weekly_margin_interest_test.go
@@ -257,6 +257,44 @@ func TestWeeklyMarginInterestService_GetWeeklyMarginInterestByCodeAndDateRange(t
 	}
 }
 
+func TestWeeklyMarginInterestService_GetWeeklyMarginInterestByCodeAndDate(t *testing.T) {
+	// Setup
+	mockClient := client.NewMockClient()
+	service := NewWeeklyMarginInterestService(mockClient)
+
+	// Mock response
+	mockResponse := WeeklyMarginInterestResponse{
+		Data: []WeeklyMarginInterest{
+			{
+				Date:    "2023-03-24",
+				Code:    "86970",
+				IssType: "1",
+				ShrtVol: 2300.0,
+				LongVol: 15400.0,
+			},
+		},
+		PaginationKey: "",
+	}
+	mockClient.SetResponse("GET", "/markets/margin-interest?code=86970&date=20230324", mockResponse)
+
+	// Execute
+	data, err := service.GetWeeklyMarginInterestByCodeAndDate("86970", "20230324")
+
+	// Verify
+	if err != nil {
+		t.Fatalf("GetWeeklyMarginInterestByCodeAndDate() error = %v", err)
+	}
+	if len(data) != 1 {
+		t.Errorf("GetWeeklyMarginInterestByCodeAndDate() returned %d items, want 1", len(data))
+	}
+	if data[0].Code != "86970" {
+		t.Errorf("GetWeeklyMarginInterestByCodeAndDate() returned code %v, want 86970", data[0].Code)
+	}
+	if data[0].Date != "2023-03-24" {
+		t.Errorf("GetWeeklyMarginInterestByCodeAndDate() returned date %v, want 2023-03-24", data[0].Date)
+	}
+}
+
 func TestWeeklyMarginInterest_IsCredit(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Summary
- 全サービスのAPIリクエストパターンを網羅するコンビニエンスメソッドを追加
- APIドキュメントに記載されたパラメータ組み合わせに対応する便利メソッドが不足していた箇所を統一的に補完
- 対象サービス: Quotes, Statements, Indices, Listed, ShortSelling, ShortSellingPositions, TradesSpec, WeeklyMarginInterest, FSDetails, TradingCalendar

## Changes

| Service | Added Methods |
|---------|--------------|
| QuotesService | `GetDailyQuotesByCodeAndDateRange`, `GetDailyQuotesByCodeAndDate` |
| StatementsService | `GetStatementsByCodeAndDate` |
| IndicesService | `GetIndicesByCodeAndDate` |
| ListedService | `ListedInfoParams`導入, `GetAllListedInfo`, `GetListedInfoByCode`, `GetListedInfoByDate`, `GetListedInfoByCodeAndDate` |
| ShortSellingService | `GetShortSellingBySectorAndDate` |
| ShortSellingPositionsService | `GetShortSellingPositionsByCodeAndDisclosedDate`, `GetShortSellingPositionsByCodeAndCalculatedDate` |
| TradesSpecService | `GetTradesSpecBySectionAndDateRange` |
| WeeklyMarginInterestService | `GetWeeklyMarginInterestByCodeAndDate` |
| FSDetailsService | `GetFSDetailsByCodeAndDate` |
| TradingCalendarService | `GetAllTradingCalendar`, `GetTradingCalendarByHolidayDivision`, `GetTradingCalendarByHolidayDivisionAndDateRange` |

## Test plan
- [x] 全追加メソッドの単体テスト追加済み
- [x] `make test` パス
- [x] `make lint` パス